### PR TITLE
fix: handle git describe when no tags exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ COLOR_RED = \033[31m
 
 PROJECT := huskyCI
 
-TAG := $(shell git describe --tags --abbrev=0)
+TAG := $(shell git describe --tags --abbrev=0 2>/dev/null || git describe --always --abbrev=0)
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-COMMIT := $(shell git rev-parse $(TAG))
+COMMIT := $(shell git rev-parse HEAD)
 LDFLAGS := '-X "main.version=$(TAG)" -X "main.commit=$(COMMIT)" -X "main.date=$(DATE)"'
 
 ## Builds all project binaries


### PR DESCRIPTION
Fix build-all target failing with 'fatal: No names found, cannot describe anything' error when repository has no tags.

Changes:
- Update TAG variable to fallback to commit hash when no tags exist
- Update COMMIT variable to use HEAD instead of TAG for better reliability

### Description

Motivation for this PR. Linking the related issue is enough:

Closes #...

### Proposed Changes

Changes that this PR will introduce. Are there any breaking changes?

### Testing

How can the reviewer assert that the modifications are working as intended? A sequence of commands is just fine:

```
make install
curl example.com
```
