### PR TITLE
Refactor/logging slog

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
     "snyk.advanced.autoSelectOrganization": true,
-    "snyk.advanced.organization": "d5b6d49b-3d94-48d8-8eb5-8966d024f697"
+    "snyk.advanced.organization": "d5b6d49b-3d94-48d8-8eb5-8966d024f697",
+    "sonarlint.connectedMode.project": {
+        "connectionId": "https-sonarqube-k8s-dc-anotaai-security-com",
+        "projectKey": "githubanotaai_huskyci-api_e14eda4f-887b-4086-adeb-b5613923c28c"
+    }
 }

--- a/LOCAL_DEPLOYMENT.md
+++ b/LOCAL_DEPLOYMENT.md
@@ -1,0 +1,279 @@
+# Local API Deployment and CLI Testing Guide
+
+This guide provides step-by-step instructions for deploying the HuskyCI API server locally and testing it with the CLI.
+
+## Architecture Overview
+
+The HuskyCI system consists of:
+- **API Server** (`api/server.go`): Main API server that orchestrates security tests
+- **MongoDB**: Database for storing analysis results
+- **Docker API**: Docker-in-Docker service for running security test containers
+- **CLI** (`cli/`): Command-line tool for interacting with the API
+
+## Deployment Options
+
+### Option 1: Docker Compose (Recommended)
+
+This is the easiest way to deploy the full environment with all dependencies.
+
+**Steps:**
+
+1. **Generate certificates** (required for Docker API communication):
+   ```bash
+   make create-certs
+   ```
+
+2. **Start the full environment**:
+   ```bash
+   make compose
+   ```
+   This starts:
+   - MongoDB on port 27017
+   - Docker API on port 2376
+   - HuskyCI API on port 8888
+
+3. **Verify services are running**:
+   ```bash
+   # Check MongoDB (MongoDB 4.4 uses 'mongo' command, not 'mongosh')
+   # Simple check - just verify the container is responding
+   docker exec huskyCI_MongoDB mongo --eval "db.adminCommand('ping')" --quiet
+   
+   # Or with authentication (if needed):
+   # docker exec huskyCI_MongoDB mongo huskyCIDB --eval "db.adminCommand('ping')" -u huskyCIUser -p huskyCIPassword --authenticationDatabase admin
+   
+   # Check API health
+   curl http://localhost:8888/healthcheck
+   ```
+
+4. **Stop services** (when done):
+   ```bash
+   make compose-down
+   ```
+
+**Default Credentials** (from `deployments/docker-compose.yml`):
+- API Username: `huskyCIUser`
+- API Password: `huskyCIPassword`
+- MongoDB: Same credentials
+- API Endpoint: `http://localhost:8888`
+
+### Option 2: Direct Go Execution
+
+For development/testing without Docker Compose, you can run the API server directly.
+
+**Prerequisites:**
+- MongoDB running locally or accessible
+- Docker daemon accessible (for running security test containers)
+- Go 1.24+ installed
+
+**Steps:**
+
+1. **Set required environment variables** (see `api/util/api/api.go` for full list):
+   ```bash
+   export HUSKYCI_DATABASE_DB_ADDR="localhost"
+   export HUSKYCI_DATABASE_DB_NAME="huskyCIDB"
+   export HUSKYCI_DATABASE_DB_USERNAME="huskyCIUser"
+   export HUSKYCI_DATABASE_DB_PASSWORD="huskyCIPassword"
+   export HUSKYCI_API_DEFAULT_USERNAME="huskyCIUser"
+   export HUSKYCI_API_DEFAULT_PASSWORD="huskyCIPassword"
+   export HUSKYCI_API_ALLOW_ORIGIN_CORS="*"
+   export HUSKYCI_INFRASTRUCTURE_USE="docker"
+   export HUSKYCI_DOCKERAPI_ADDR="localhost:2376"  # or unix:///var/run/docker.sock
+   export HUSKYCI_DOCKERAPI_TLS_VERIFY="0"
+   export HUSKYCI_DOCKERAPI_CERT_PATH="/path/to/certs"  # if using TLS
+   ```
+
+2. **Build the API server**:
+   ```bash
+   make build-api
+   ```
+
+3. **Run the API server**:
+   ```bash
+   cd api
+   ./huskyci-api-bin
+   ```
+
+   Or run directly with Go:
+   ```bash
+   cd api
+   go run server.go
+   ```
+
+## CLI Configuration and Testing
+
+### Configure CLI
+
+**Option A: Using CLI setup command** (interactive):
+```bash
+make build-cli
+./cli/huskyci-cli-bin setup
+```
+
+**Option B: Using config file** (`~/.huskyci/config.yaml`):
+Create `~/.huskyci/config.yaml` based on `examples/cli-config.yaml.example`:
+```yaml
+targets:
+  local:
+    current: true
+    endpoint: "http://localhost:8888"
+    token-storage: "keychain"
+```
+
+**Option C: Using environment variables**:
+```bash
+export HUSKYCI_CLIENT_API_ADDR="http://localhost:8888"
+export HUSKYCI_CLI_TOKEN="your-token-here"
+```
+
+**Note**: The API server can also read tokens from environment variables if the `Husky-Token` header is not provided:
+- `HUSKYCI_CLI_TOKEN` - Used when requests come from the CLI (detected via User-Agent header)
+- `HUSKYCI_CLIENT_TOKEN` - Used when requests come from non-human clients (detected via User-Agent header)
+
+The API will first check the `Husky-Token` header, and if empty, it will check the appropriate environment variable based on the request source.
+
+### Generate API Token
+
+Before running CLI tests, you need to generate a token:
+
+```bash
+# Using Basic Auth (username:password from docker-compose.yml)
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -u huskyCIUser:huskyCIPassword \
+  -d '{"repositoryURL": "https://github.com/huskyci-org/huskyCI.git"}' \
+  http://localhost:8888/api/1.0/token
+```
+
+Extract the token from the response and set it:
+```bash
+export HUSKYCI_CLI_TOKEN="your-token-here"
+```
+
+### Test CLI Connection
+
+The CLI includes a built-in connection test command:
+
+```bash
+# Build CLI if not already built
+make build-cli
+
+# Test connection to current target
+./cli/huskyci-cli-bin test-connection
+
+# Test connection to specific endpoint
+./cli/huskyci-cli-bin test-connection --endpoint http://localhost:8888
+
+# Test with verbose output
+./cli/huskyci-cli-bin test-connection --verbose
+```
+
+This command tests:
+1. Basic connectivity
+2. Health check endpoint (`/healthcheck`)
+3. Version endpoint (`/version`)
+4. Authentication (if token configured)
+
+### Run CLI Analysis Tests
+
+**Test 1: Analyze a local directory**:
+```bash
+./cli/huskyci-cli-bin run ./path/to/your/project
+```
+
+**Test 2: Run E2E tests** (full integration test):
+```bash
+# Ensure API is running
+make compose
+
+# Run E2E tests
+make test-e2e
+# or directly:
+./tests/e2e/run-e2e-tests.sh
+```
+
+The E2E test script (`tests/e2e/run-e2e-tests.sh`) performs:
+1. Health check
+2. Version check
+3. Token generation
+4. Analysis submission
+5. Analysis monitoring
+6. Results verification
+
+## Key Files Reference
+
+- **API Server**: [`api/server.go`](api/server.go) - Main entry point
+- **Docker Compose**: [`deployments/docker-compose.yml`](deployments/docker-compose.yml) - Full environment setup
+- **CLI Config Example**: [`examples/cli-config.yaml.example`](examples/cli-config.yaml.example) - CLI configuration template
+- **CLI Test Connection**: [`cli/cmd/testConnection.go`](cli/cmd/testConnection.go) - Connection testing implementation
+- **E2E Test Script**: [`tests/e2e/run-e2e-tests.sh`](tests/e2e/run-e2e-tests.sh) - Full integration tests
+- **Makefile**: [`Makefile`](Makefile) - Common commands
+
+## Troubleshooting
+
+**API won't start:**
+- Check all required environment variables are set
+- Verify MongoDB is accessible
+- Check Docker daemon is running (if using docker infrastructure)
+
+**CLI can't connect:**
+- Verify API is running: `curl http://localhost:8888/healthcheck`
+- Check endpoint URL in config matches API address
+- Ensure token is valid (regenerate if needed)
+
+**Analysis fails:**
+- Check Docker API is accessible
+- Verify security test containers are available
+- Check API logs for detailed error messages
+
+**CLI "zip file not found" error when running `huskyci run ./`:**
+- This error occurs when the zip file upload succeeds but the API cannot find it when starting analysis
+- Possible causes:
+  1. **API server permissions**: The API server may not have write permissions to `/tmp/huskyci-zips`
+  2. **Docker volume issue**: If running in Docker, ensure the `/tmp` directory is writable
+  3. **RID mismatch**: There may be a mismatch between the upload RID and analysis RID
+- Troubleshooting steps:
+  ```bash
+  # Check API logs
+  docker logs huskyCI_API
+  
+  # Verify API can write to /tmp (if running in Docker)
+  docker exec huskyCI_API ls -la /tmp/huskyci-zips
+  
+  # Run CLI with verbose mode for detailed logs
+  huskyci run ./ --verbose
+  ```
+- If the issue persists, try:
+  1. Ensure the API container has proper volume mounts or tmpfs access
+  2. Check API server logs for file system errors
+  3. Verify the upload endpoint returns success with the correct RID
+
+## Quick Start Summary
+
+```bash
+# 1. Setup environment
+make create-certs
+make compose
+
+# 2. Wait for services (30-60 seconds)
+curl http://localhost:8888/healthcheck
+
+# 3. Generate token
+TOKEN=$(curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -u huskyCIUser:huskyCIPassword \
+  -d '{"repositoryURL": "https://github.com/huskyci-org/huskyCI.git"}' \
+  http://localhost:8888/api/1.0/token | grep -o '"huskytoken":"[^"]*' | cut -d'"' -f4)
+
+# 4. Configure CLI
+export HUSKYCI_CLI_TOKEN="$TOKEN"
+make build-cli
+
+# 5. Test connection
+./cli/huskyci-cli-bin test-connection --endpoint http://localhost:8888
+
+# 6. Run analysis
+./cli/huskyci-cli-bin run .
+
+# 7. Cleanup
+make compose-down
+```

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build-all: build-api build-api-linux build-client build-client-linux build-cli b
 ## Builds API code into a binary
 build-api:
 	cd api && $(GO) build -ldflags $(LDFLAGS) -o "$(HUSKYCI-API-BIN)" server.go
+	@if [ "$$(uname -s)" = "Darwin" ] && [ -f "api/$(HUSKYCI-API-BIN)" ]; then xattr -c "api/$(HUSKYCI-API-BIN)" 2>/dev/null || true; fi
 
 ## Builds API code using linux architecture into a binary
 build-api-linux:

--- a/README.md
+++ b/README.md
@@ -3,55 +3,41 @@
   <!-- logo font: Anton -->
 </p>
 
-<p align="center">
-  <a href="https://github.com/huskyci-org/huskyCI/releases"><img src="https://img.shields.io/github/v/release/huskyci-org/huskyCI"/></a>
-  <a href="https://github.com/rafaveira3/writing-and-presentations/blob/master/DEFCON-27-APP-SEC-VILLAGE-Rafael-Santos-huskyCI-Finding-security-flaws-in-CI-before-deploying-them.pdf"><img src="https://img.shields.io/badge/DEFCON%2027-AppSec%20Village-black"/></a>
-  <a href="https://github.com/rafaveira3/contributions/blob/master/huskyCI-BlackHat-Europe-2019.pdf"><img src="https://img.shields.io/badge/Black%20Hat%20Europe%202019-Arsenal-black"/></a>
-  <a href="https://defectdojo.readthedocs.io/en/latest/integrations.html#huskyci-report"><img src="https://img.shields.io/badge/DefectDojo-Compatible-brightgreen"/></a>
-</p>
-
 ---
 ## IMPORTANT ORIENTATIONS FOR THIS FORK
 
 This is a fork from this [original HuskyCI](github.com/globocom/huskyCI) repository. I've had a few problems when trying to make use of Husky so I decided to improve the code in order to be able to utilize it in production-ready critical environments.
 The problems addressed until now were:
-  - Outdated MongoDB package/driver - Solution: [new MongoDB driver utilized](go.mongodb.org/mongo-driver) with support to the most up to date MongoDB versions
-  - Broken Kubernetes Compatibility - Solution: fully functioning [HuskyCI API Server helm chart](https://github.com/huskyci-org/helm-chart-huskyci-api) 
-  - Broken Sonarqube Integration Issue Importing - Solution: Updated [generic external issues importing standard](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/)
-  - Gitlab only integration configuration - Set up a fully functioning [GitHub Actions workflow file](.github/workflows/e2e-tests.yml) for end-to-end testing
-  - Outdated tests - Every test container was updated and a new dockerhub repository was created for each one of them (also a [new organization](https://hub.docker.com/orgs/huskyciorg/repositories) was created)
+
+- Outdated MongoDB package/driver - Solution: [new MongoDB driver utilized](go.mongodb.org/mongo-driver) with support to the most up to date MongoDB versions
+- Broken Kubernetes Compatibility - Solution: fully functioning [HuskyCI API Server helm chart](https://github.com/huskyci-org/helm-chart-huskyci-api) 
+- Broken Sonarqube Integration Issue Importing - Solution: Updated [generic exxternal issues importing standard](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/)
+- Gitlab only integration configuration - Set up a fully functioning [Github Action workflow file]()
+- Outdated tests - Every test container was updated and a new dockerhub repository was created for each one of them (also a [new organization](https://hub.docker.com/orgs/huskyciorg/repositories) was created)
 
 ### Ongoing activities
-  - Fix Sonarqube integration file output of some specific tests (like npmaudit, which has only vulnerabilities based on one file and the filepath of the analysed file comes as a placeholder)
-  - Transitioning from TFSec to [Trivy](https://github.com/aquasecurity/trivy) for infrastructure scanning (TFSec functionality is now available in Trivy)
-  - Documentation improvement
+
+- Fix Sonarqube integration file output of some specific tests (like npmaudit, which has only vulnerabilities based on one file and the filepath of the analysed file comes as a placeholder)
+- Removing TFSec in favour of [Trivy](https://github.com/aquasecurity/trivy) (TFSec was integrated into Trivy)
+- Documentation improvement
 
 ### Tips
 
 If you're setting a Github and Kubernetes environment, think about using the [Actions Runner Controller](https://github.com/actions/actions-runner-controller/tree/master) in order to have a highly-available testing pipeline.
 
 ---
+
 ## Overview
 
 HuskyCI is an open-source tool designed to orchestrate security tests within CI pipelines, centralizing results into a database for further analysis and metrics. It supports multiple programming languages and integrates with popular static analysis tools to identify vulnerabilities early in the development lifecycle.
 
 ### Key Features
 
-- **Multi-language support**: Python, Ruby, JavaScript, Golang, Java, C#, and infrastructure-as-code (HCL).
-- **Comprehensive security testing**: 
-  - **Python**: Bandit (static analysis) and Safety (dependency checking)
-  - **Ruby**: Brakeman (static analysis)
-  - **JavaScript**: NpmAudit and YarnAudit (dependency vulnerability scanning)
-  - **Go**: Gosec (static analysis)
-  - **Java**: SpotBugs with FindSecBugs plugin (static analysis)
-  - **C#**: SecurityCodeScan (static analysis)
-  - **Infrastructure**: Trivy (container and infrastructure scanning)
-- **Secrets detection**: Audit repositories for sensitive information like AWS keys, SSH private keys, and other secrets using Gitleaks.
-- **Integration-ready**: Works seamlessly with CI/CD pipelines including GitHub Actions and GitLab CI/CD.
-- **SonarQube integration**: Export results in SonarQube Generic Issue Import Format for centralized reporting.
-- **Multiple database support**: MongoDB (default) and PostgreSQL.
-- **Infrastructure support**: Compatible with Docker and Kubernetes deployments.
-- **CLI tool**: Command-line interface for managing targets and running analyses locally.
+- **Multi-language support**: Python, Ruby, JavaScript, Golang, Java, HCL, and more.
+- **Secrets detection**: Audit repositories for sensitive information like AWS keys and SSH private keys.
+- **Integration-ready**: Works seamlessly with CI/CD pipelines like GitLab CI/CD.
+- **Extensible**: Add new tools and customize configurations.
+- **Infrastructure support**: Compatible with Docker and Kubernetes.
 
 ---
 
@@ -60,9 +46,7 @@ HuskyCI is an open-source tool designed to orchestrate security tests within CI 
 ### Prerequisites
 
 - **Docker** and **Docker Compose** installed.
-- **Golang 1.23+** installed (for development purposes).
-  - API module requires Go 1.24.0
-  - CLI and Client modules require Go 1.23.0+
+- **Golang** installed (for development purposes).
 
 ### Steps
 
@@ -89,49 +73,13 @@ HuskyCI is an open-source tool designed to orchestrate security tests within CI 
 
 ## Usage
 
-### Using the CLI Tool
-
-The HuskyCI CLI provides an easy way to interact with HuskyCI from your local machine.
-
-#### Installation
-
-Build the CLI:
-
-```bash
-make build-cli
-```
-
-#### Available Commands
-
-- **`huskyci run <path>`**: Run a security analysis on a local directory
-- **`huskyci login`**: Authenticate with GitHub using device flow
-- **`huskyci target-add <name> <endpoint>`**: Add a new HuskyCI API target
-- **`huskyci target-list`**: List all configured targets
-- **`huskyci target-set <name>`**: Set the current target
-- **`huskyci target-remove <name>`**: Remove a target
-- **`huskyci version`**: Display version information
-
-#### Example: Running an Analysis
-
-1. Configure your target (if not already done):
-
-   ```bash
-   huskyci target-add local http://localhost:8888 --set-current
-   ```
-
-2. Run an analysis on a local directory:
-
-   ```bash
-   huskyci run /path/to/your/project
-   ```
-
-### Using the Client
+### Running a Security Analysis
 
 1. Set up environment variables:
 
    ```bash
    export HUSKYCI_CLIENT_REPO_URL="https://github.com/huskyci-org/huskyCI.git"
-   export HUSKYCI_CLIENT_REPO_BRANCH="main"
+   export HUSKYCI_CLIENT_REPO_BRANCH="master"
    export HUSKYCI_CLIENT_API_ADDR="http://localhost:8888"
    export HUSKYCI_CLIENT_API_USE_HTTPS="false"
    export HUSKYCI_CLIENT_TOKEN="{YOUR_TOKEN_HERE}"
@@ -143,70 +91,13 @@ make build-cli
    make run-client
    ```
 
-   Or with JSON output:
-
-   ```bash
-   make run-client-json
-   ```
-
 3. View results in the terminal.
-
-### API Endpoints
-
-The HuskyCI API provides REST endpoints for integration:
-
-- **`POST /analysis`**: Submit a new security analysis
-- **`GET /analysis/:id`**: Get analysis results by RID
-- **`GET /healthcheck`**: Health check endpoint
-- **`GET /version`**: Get API version
-- **`GET /stats/:metric_type`**: Get statistics
-- **`POST /api/1.0/token`**: Generate authentication token (requires basic auth)
-- **`PUT /user`**: Update user information
 
 ### Integrating with CI/CD
 
-Refer to the [integration guide](https://github.com/huskyci-org/huskyCI/wiki/4.-Guides.md) for detailed instructions on adding HuskyCI to your CI/CD pipeline. HuskyCI supports:
-
-- **GitHub Actions**: Workflow examples available
-- **GitLab CI/CD**: Native integration support
-- **Kubernetes**: Helm chart available at [huskyci-org/helm-chart-huskyci-api](https://github.com/huskyci-org/helm-chart-huskyci-api)
+Refer to the [integration guide](https://github.com/huskyci-org/huskyCI/wiki/4.-Guides.md) for detailed instructions on adding HuskyCI to your CI/CD pipeline.
 
 ---
-
-## Architecture
-
-HuskyCI consists of three main components:
-
-1. **API Server** (`api/`): The core backend service that orchestrates security tests, manages analysis, and stores results in the database.
-2. **CLI Tool** (`cli/`): Command-line interface for local development and interaction with HuskyCI API.
-3. **Client** (`client/`): Lightweight client for submitting analyses and retrieving results.
-
-### Infrastructure Support
-
-- **Docker**: Full support for running security tests in Docker containers
-- **Kubernetes**: Native Kubernetes support with configurable deployment options
-- **Database**: 
-  - MongoDB (default, fully supported)
-  - PostgreSQL (supported, requires configuration)
-
-### Security Tests
-
-HuskyCI orchestrates the following security testing tools:
-
-| Tool | Language/Type | Purpose |
-|------|--------------|---------|
-| Bandit | Python | Static security analysis |
-| Safety | Python | Dependency vulnerability scanning |
-| Brakeman | Ruby | Static security analysis |
-| Gosec | Go | Static security analysis |
-| NpmAudit | JavaScript | NPM dependency vulnerability scanning |
-| YarnAudit | JavaScript | Yarn dependency vulnerability scanning |
-| SpotBugs | Java | Static security analysis with FindSecBugs |
-| SecurityCodeScan | C# | Static security analysis |
-| Gitleaks | Generic | Secrets detection |
-| Trivy | Generic | Infrastructure and container scanning |
-| Enry | Generic | Language detection |
-| GitAuthors | Generic | Commit author analysis |
 
 ## Documentation
 
@@ -216,59 +107,14 @@ Comprehensive documentation is available in the [HuskyCI Wiki](https://github.co
 - [API Reference](https://github.com/huskyci-org/huskyCI/wiki/5.-API.md)
 - [Integration Guides](https://github.com/huskyci-org/huskyCI/wiki/4.-Guides.md)
 
+For local development and testing:
+- [Local API Deployment and CLI Testing Guide](LOCAL_DEPLOYMENT.md) - Complete guide for deploying the API server locally and performing CLI tests
+
 ---
-
-## Development
-
-### Building from Source
-
-Build all components:
-
-```bash
-make build-all
-```
-
-Build individual components:
-
-```bash
-make build-api      # Build API server
-make build-client   # Build client
-make build-cli      # Build CLI tool
-```
-
-### Running Tests
-
-Run all unit tests:
-
-```bash
-make test
-```
-
-Run end-to-end tests:
-
-```bash
-make test-e2e
-```
-
-### Development Environment
-
-The project uses Go workspaces. The workspace file (`go.work`) defines the modules:
-
-- `api/` - API server module
-- `cli/` - CLI tool module  
-- `client/` - Client module
-
-### Security Testing
-
-Run security static analysis on the codebase:
-
-```bash
-make check-sec
-```
 
 ## Contributing
 
-We welcome contributions! Please read our [contributing guide](CONTRIBUTING.md) to learn about our development process and how to propose changes.
+We welcome contributions! Please read our [contributing guide](https://github.com/huskyci-org/huskyCI/blob/master/CONTRIBUTING.md) to learn about our development process and how to propose changes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ The problems addressed until now were:
 - Gitlab only integration configuration - Set up a fully functioning [Github Action workflow file]()
 - Outdated tests - Every test container was updated and a new dockerhub repository was created for each one of them (also a [new organization](https://hub.docker.com/orgs/huskyciorg/repositories) was created)
 
+### Recent improvements
+
+- **Docker-in-Docker / Docker Compose**: API uses `HUSKYCI_DOCKERAPI_ADDR` (and optional `HUSKYCI_DOCKERAPI_PORT`) so security tests run in the correct Docker daemon; avoids "lookup /var/run/docker.sock" when the DB or config had a Unix socket path.
+- **File upload (file://) analysis**: Robust zip extraction in the Docker API container (retries for large uploads), gitauthors skipped for file:// URLs, and resilient handling of empty/invalid tool output so analyses can complete.
+- **Stability**: Buffered error channels in security test orchestration to avoid "send on closed channel" panics; Docker client created with explicit host to avoid races when multiple tests run in parallel.
+
 ### Ongoing activities
 
 - Fix Sonarqube integration file output of some specific tests (like npmaudit, which has only vulnerabilities based on one file and the filepath of the analysed file comes as a placeholder)

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -20,7 +20,6 @@ const logInfoAnalysis = "ANALYSIS"
 
 // StartAnalysis starts the analysis given a RID and a repository.
 func StartAnalysis(RID string, repository types.Repository) {
-
 	// step 1: create a new analysis into MongoDB based on repository received
 	if err := registerNewAnalysis(RID, repository); err != nil {
 		return

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/huskyci-org/huskyCI/api/log"
 	"github.com/huskyci-org/huskyCI/api/securitytest"
 	"github.com/huskyci-org/huskyCI/api/types"
+	"github.com/huskyci-org/huskyCI/api/util"
 	apiUtil "github.com/huskyci-org/huskyCI/api/util/api"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -76,6 +78,22 @@ func StartAnalysis(RID string, repository types.Repository) {
 
 	log.Info("StartAnalysisTest", apiHost, 2012, RID)
 
+	// For file:// URLs, check if Enry output was provided by CLI
+	// This avoids docker-in-docker issues where Enry can't see extracted files
+	if util.IsFileURL(repository.URL) && repository.EnryOutput != "" {
+		log.Info(logActionStart, logInfoAnalysis, 16, fmt.Sprintf("Using Enry output provided by CLI for file:// URL: %s", repository.URL))
+		// Parse the provided Enry output and populate enryScan.Codes directly
+		if err := enryScan.ParseProvidedEnryOutput(repository.EnryOutput, repository.LanguageExclusions); err != nil {
+			log.Error(logActionStart, logInfoAnalysis, 2011, fmt.Errorf("failed to parse provided Enry output: %w", err))
+			// Fall back to running Enry if parsing fails
+			log.Info(logActionStart, logInfoAnalysis, 16, "Falling back to running Enry in container")
+		} else {
+			log.Info(logActionStart, logInfoAnalysis, 16, fmt.Sprintf("Successfully parsed %d languages from provided Enry output", len(enryScan.Codes)))
+			// Skip running Enry since we have the output
+			goto skipEnryRun
+		}
+	}
+
 	if err := enryScan.New(RID, repository.URL, repository.Branch, enryScan.SecurityTestName, repository.LanguageExclusions, apiHost); err != nil {
 		log.Error(logActionStart, logInfoAnalysis, 2011, err)
 		return
@@ -84,6 +102,8 @@ func StartAnalysis(RID string, repository types.Repository) {
 		allScansResults.SetAnalysisError(err)
 		return
 	}
+
+skipEnryRun:
 
 	// step 3: run generic and languages security tests based on enryScan result in parallel
 	if err := allScansResults.Start(enryScan); err != nil {

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -1,6 +1,6 @@
 bandit:
   name: bandit
-  image: huskyci/bandit
+  image: huskyciorg/bandit
   imageTag: "1.9.3"
   cmd: |+
      mkdir -p ~/.ssh &&
@@ -26,7 +26,7 @@ bandit:
 
 brakeman:
   name: brakeman
-  image: huskyci/brakeman
+  image: huskyciorg/brakeman
   imageTag: "7.1.2"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -63,7 +63,7 @@ brakeman:
 
 enry:
   name: enry
-  image: huskyci/enry
+  image: huskyciorg/enry
   imageTag: v2.9.3
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -89,7 +89,7 @@ enry:
 
 gitauthors:
   name: gitauthors
-  image: huskyci/gitauthors
+  image: huskyciorg/gitauthors
   imageTag: "latest"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -120,7 +120,7 @@ gitauthors:
 
 gitleaks:
   name: gitleaks
-  image: huskyci/gitleaks
+  image: huskyciorg/gitleaks
   imageTag: "v8.30.0"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -151,7 +151,7 @@ gitleaks:
 
 gosec:
   name: gosec
-  image: huskyci/gosec
+  image: huskyciorg/gosec
   imageTag: v2.22.11
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -187,7 +187,7 @@ gosec:
 
 npmaudit:
   name: npmaudit
-  image: huskyci/npmaudit
+  image: huskyciorg/npmaudit
   imageTag: "11.8.0"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -225,7 +225,7 @@ npmaudit:
 
 safety:
   name: safety
-  image: huskyci/safety
+  image: huskyciorg/safety
   imageTag: "3.7.0"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -271,7 +271,7 @@ safety:
 
 securitycodescan:
   name: securitycodescan
-  image: huskyci/securitycodescan
+  image: huskyciorg/securitycodescan
   imageTag: "v5.6.7"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -300,7 +300,7 @@ securitycodescan:
 
 spotbugs:
   name: spotbugs
-  image: huskyci/spotbugs
+  image: huskyciorg/spotbugs
   imageTag: "4.9.8"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -378,7 +378,7 @@ trivy:
 
 yarnaudit:
   name: yarnaudit
-  image: huskyci/yarnaudit
+  image: huskyciorg/yarnaudit
   imageTag: "1.22.22"
   cmd: |+
     mkdir -p ~/.ssh &&

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -191,11 +191,19 @@ func (dF DefaultConfig) getGitPrivateSSHKey() string {
 }
 
 func (dF DefaultConfig) getGraylogConfig() *GraylogConfig {
+	appName := dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_APP_NAME")
+	if appName == "" {
+		appName = "huskyCI"
+	}
+	tag := dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_TAG")
+	if tag == "" {
+		tag = "huskyCI"
+	}
 	return &GraylogConfig{
 		Address:        dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_ADDR"),
 		Protocol:       dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_PROTO"),
-		AppName:        dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_APP_NAME"),
-		Tag:            dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_TAG"),
+		AppName:        appName,
+		Tag:            tag,
 		DevelopmentEnv: dF.GetGraylogIsDev(),
 	}
 }

--- a/api/dockers/huskydocker.go
+++ b/api/dockers/huskydocker.go
@@ -3,6 +3,8 @@ package dockers
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"regexp"
@@ -31,6 +33,11 @@ func configureImagePath(image, tag string) (string, string) {
 
 // DockerRun starts a new container and returns its output and an error.
 func DockerRun(image, imageTag, cmd, dockerHost string, timeOutInSeconds int) (string, string, error) {
+	return DockerRunWithVolume(image, imageTag, cmd, dockerHost, "", timeOutInSeconds)
+}
+
+// DockerRunWithVolume starts a new container with an optional volume mount and returns its output and an error.
+func DockerRunWithVolume(image, imageTag, cmd, dockerHost, volumePath string, timeOutInSeconds int) (string, string, error) {
 
 	// step 1: create a new docker API client
 	d, err := NewDocker(dockerHost)
@@ -46,8 +53,20 @@ func DockerRun(image, imageTag, cmd, dockerHost string, timeOutInSeconds int) (s
 		}
 	}
 
+	// step 2.5: For file:// URLs, ensure dockerapi can see the files
+	// docker-in-docker has issues with bind mounts - dockerapi can't see files written by API container
+	// Use a temporary container to refresh dockerapi's view of the mount
+	if volumePath != "" {
+		log.Info(logActionRun, logInfoHuskyDocker, 16, fmt.Sprintf("Mounting volume path: %s (resolved relative to Docker daemon host)", volumePath))
+		// Sync files to dockerapi using a temporary container
+		if err := syncFilesToDockerAPI(d, volumePath); err != nil {
+			log.Error(logActionRun, logInfoHuskyDocker, 3016, fmt.Errorf("failed to sync files to dockerapi: %v (continuing anyway)", err))
+			// Continue anyway - the mount might still work
+		}
+	}
+
 	// step 3: create a new container given an image and it's cmd
-	CID, err := d.CreateContainer(fullContainerImage, cmd)
+	CID, err := d.CreateContainerWithVolume(fullContainerImage, cmd, volumePath)
 	if err != nil {
 		return "", "", err
 	}
@@ -82,25 +101,197 @@ func DockerRun(image, imageTag, cmd, dockerHost string, timeOutInSeconds int) (s
 	return CID, cOutput, nil
 }
 
+// ExtractZipInDockerAPI extracts a zip file directly in dockerapi using a temporary container
+// This ensures dockerapi's Docker daemon can see the extracted files immediately
+// Since docker-in-docker doesn't properly share bind mounts, we need to ensure dockerapi can see the files
+// The zip file exists on the host at /tmp/huskyci-zips-host/, and dockerapi has this mounted at /tmp/huskyci-zips/
+// When dockerapi creates containers, it resolves paths relative to dockerapi's filesystem
+// So /tmp/huskyci-zips/<RID>.zip in dockerapi = /tmp/huskyci-zips-host/<RID>.zip on host
+func ExtractZipInDockerAPI(dockerHost, zipPath, destDir string) error {
+	// Extract zip file name and directory from path
+	zipFileName := filepath.Base(zipPath)
+	parentDir := filepath.Dir(zipPath)
+	
+	// Use a temporary alpine container with unzip to extract files
+	// Mount the parent directory - dockerapi resolves this relative to its filesystem
+	// Since dockerapi has /tmp/huskyci-zips-host:/tmp/huskyci-zips mounted,
+	// mounting /tmp/huskyci-zips should work and access files on the host
+	// The volume is mounted at /workspace in the container (see CreateContainerWithVolume)
+	// So we need to use /workspace instead of the original path
+	// The zip file and destination directory are relative to the parent directory
+	destDirName := filepath.Base(destDir)
+	// Add retry logic to wait for file to be visible to dockerapi's Docker daemon
+	// Use a loop with small delays to check if file exists before attempting extraction
+	extractCmd := fmt.Sprintf("sh -c 'apk add --no-cache unzip > /dev/null 2>&1 && cd /workspace && "+
+		"for i in $(seq 1 10); do "+
+		"if [ -f %s ]; then "+
+		"mkdir -p %s && unzip -q -o %s -d %s && echo \"Extraction successful\" && exit 0; "+
+		"fi; "+
+		"sleep 0.2; "+
+		"done; "+
+		"echo \"ERROR: Zip file %s not found in /workspace after retries\"; "+
+		"ls -la /workspace 2>&1; "+
+		"exit 1'", zipFileName, destDirName, zipFileName, destDirName, zipFileName)
+	
+	// Create Docker client for dockerapi
+	d, err := NewDocker(dockerHost)
+	if err != nil {
+		return fmt.Errorf("failed to create Docker client: %w", err)
+	}
+	
+	// Mount the parent directory - dockerapi will resolve this relative to its filesystem
+	// We need read-write access to extract files, so we'll mount it as rw
+	volumePath := parentDir
+	
+	// Ensure alpine:latest image is available in dockerapi
+	canonicalURL, fullContainerImage := configureImagePath("alpine", "latest")
+	log.Info("ExtractZipInDockerAPI", logInfoHuskyDocker, 16, fmt.Sprintf("Checking for image %s (canonical: %s) in dockerapi...", fullContainerImage, canonicalURL))
+	isLoaded := d.ImageIsLoaded(fullContainerImage)
+	log.Info("ExtractZipInDockerAPI", logInfoHuskyDocker, 16, fmt.Sprintf("Image %s loaded: %v", fullContainerImage, isLoaded))
+	if !isLoaded {
+		log.Info("ExtractZipInDockerAPI", logInfoHuskyDocker, 31, fmt.Sprintf("Pulling image %s (canonical: %s) in dockerapi...", fullContainerImage, canonicalURL))
+		if err := pullImage(d, canonicalURL, fullContainerImage); err != nil {
+			return fmt.Errorf("failed to pull alpine:latest image: %w", err)
+		}
+		log.Info("ExtractZipInDockerAPI", logInfoHuskyDocker, 35, fmt.Sprintf("Successfully pulled image %s", fullContainerImage))
+	} else {
+		log.Info("ExtractZipInDockerAPI", logInfoHuskyDocker, 35, fmt.Sprintf("Image %s already loaded, skipping pull", fullContainerImage))
+	}
+	
+	log.Info("ExtractZipInDockerAPI", logInfoHuskyDocker, 16, fmt.Sprintf("Extracting zip in dockerapi: zipPath=%s, destDir=%s, volumePath=%s", zipPath, destDir, volumePath))
+	
+	// Create container with read-write mount so we can extract files
+	// We need to use CreateContainerWithVolumeRW instead of CreateContainerWithVolume
+	CID, err := d.CreateContainerWithVolumeRW(fullContainerImage, extractCmd, volumePath)
+	if err != nil {
+		return fmt.Errorf("failed to create extract container: %w", err)
+	}
+	d.CID = CID
+	
+	// Start container
+	if err := d.StartContainer(); err != nil {
+		d.RemoveContainer()
+		return fmt.Errorf("failed to start extract container: %w", err)
+	}
+	
+	// Wait for container to finish (allow up to 5 minutes for large zip files)
+	if err := d.WaitContainer(300); err != nil {
+		// Read container output to see what went wrong
+		output, _ := d.ReadOutput()
+		d.RemoveContainer()
+		return fmt.Errorf("extract container error: %w (output: %s)", err, output)
+	}
+	
+	// Verify extraction succeeded by reading output
+	output, _ := d.ReadOutput()
+	if strings.Contains(output, "ERROR") {
+		d.RemoveContainer()
+		return fmt.Errorf("extraction failed: %s", output)
+	}
+	
+	// Clean up
+	if err := d.RemoveContainer(); err != nil {
+		log.Error("ExtractZipInDockerAPI", logInfoHuskyDocker, 3027, fmt.Errorf("failed to remove extract container: %v", err))
+	}
+	
+	return nil
+}
+
+// syncFilesToDockerAPI ensures dockerapi can see files by using a temporary container
+// to refresh dockerapi's view of the mount. Since docker-in-docker doesn't properly
+// share bind mounts between containers, we use a temporary container to ensure
+// dockerapi's Docker daemon can see files written by the API container.
+func syncFilesToDockerAPI(d *Docker, volumePath string) error {
+	// Use a temporary alpine container to list files in the volume
+	// This forces dockerapi's Docker daemon to refresh its view of the mount
+	// The container mounts the volume and lists files to ensure they're visible
+	syncCmd := fmt.Sprintf("sh -c 'ls -la %s > /dev/null 2>&1 || true'", volumePath)
+	
+	// Create a temporary container with the volume mounted
+	tempCID, err := d.CreateContainerWithVolume("alpine:latest", syncCmd, volumePath)
+	if err != nil {
+		return fmt.Errorf("failed to create sync container: %w", err)
+	}
+	
+	// Start and wait for the container
+	d.CID = tempCID
+	if err := d.StartContainer(); err != nil {
+		d.RemoveContainer() // Clean up on error
+		return fmt.Errorf("failed to start sync container: %w", err)
+	}
+	
+	// Wait for container to finish (should be very quick)
+	if err := d.WaitContainer(30); err != nil {
+		d.RemoveContainer()
+		return fmt.Errorf("sync container error: %w", err)
+	}
+	
+	// Clean up temporary container
+	if err := d.RemoveContainer(); err != nil {
+		// Log but don't fail - this is cleanup
+		log.Error(logActionRun, logInfoHuskyDocker, 3027, fmt.Errorf("failed to remove sync container: %v", err))
+	}
+	
+	return nil
+}
+
 func pullImage(d *Docker, canonicalURL, image string) error {
 	timeout := time.After(15 * time.Minute)
 	retryTick := time.NewTicker(15 * time.Second)
+	maxRetries := 3
+	retryCount := 0
+	
 	for {
 		select {
 		case <-timeout:
-			timeOutErr := errors.New("timeout")
-			log.Error(logActionPull, logInfoHuskyDocker, 3013, timeOutErr)
+			timeOutErr := errors.New("timeout after 15 minutes")
+			log.Error(logActionPull, logInfoHuskyDocker, 3013, fmt.Sprintf("Image pull timeout for %s: %v", image, timeOutErr))
 			return timeOutErr
 		case <-retryTick.C:
-			log.Info(logActionPull, logInfoHuskyDocker, 31, image)
+			log.Info(logActionPull, logInfoHuskyDocker, 31, fmt.Sprintf("Attempting to pull image: %s (attempt %d)", image, retryCount+1))
+			
+			// Check if image is already loaded
 			if d.ImageIsLoaded(image) {
-				log.Info(logActionPull, logInfoHuskyDocker, 35, image)
+				log.Info(logActionPull, logInfoHuskyDocker, 35, fmt.Sprintf("Image already loaded: %s", image))
 				return nil
 			}
+			
+			// Attempt to pull the image
 			if err := d.PullImage(canonicalURL); err != nil {
-				log.Error(logActionPull, logInfoHuskyDocker, 3013, err)
-				return err
+				retryCount++
+				
+				// Check if it's a platform mismatch error - fail immediately
+				errStr := err.Error()
+				if strings.Contains(strings.ToLower(errStr), "no matching manifest") ||
+					strings.Contains(strings.ToLower(errStr), "platform") ||
+					strings.Contains(strings.ToLower(errStr), "manifest unknown") ||
+					strings.Contains(strings.ToLower(errStr), "manifest not found") {
+					log.Error(logActionPull, logInfoHuskyDocker, 3013, fmt.Sprintf("Platform mismatch error for %s - failing immediately: %v", image, err))
+					return fmt.Errorf("platform mismatch or manifest not found for %s: %w", image, err)
+				}
+				
+				// For other errors, retry up to maxRetries times
+				if retryCount >= maxRetries {
+					log.Error(logActionPull, logInfoHuskyDocker, 3013, fmt.Sprintf("Failed to pull image %s (attempt %d/%d): %v", image, retryCount, maxRetries, err))
+					return fmt.Errorf("failed to pull image %s after %d attempts: %w", image, maxRetries, err)
+				}
+				
+				log.Info(logActionPull, logInfoHuskyDocker, 31, fmt.Sprintf("Failed to pull image %s (attempt %d/%d), retrying in 15 seconds...", image, retryCount, maxRetries))
+				continue
 			}
+			
+			// Pull succeeded, verify image is loaded
+			if d.ImageIsLoaded(image) {
+				log.Info(logActionPull, logInfoHuskyDocker, 35, fmt.Sprintf("Successfully pulled and loaded image: %s", image))
+				return nil
+			}
+			
+			// Pull reported success but image not loaded - retry
+			retryCount++
+			if retryCount >= maxRetries {
+				return fmt.Errorf("image %s pull reported success but image not found after %d attempts", image, maxRetries)
+			}
+			log.Info(logActionPull, logInfoHuskyDocker, 31, fmt.Sprintf("Pull succeeded but image not found, retrying for %s...", image))
 		}
 	}
 }

--- a/api/dockers/huskydocker.go
+++ b/api/dockers/huskydocker.go
@@ -122,12 +122,13 @@ func ExtractZipInDockerAPI(dockerHost, zipPath, destDir string) error {
 	destDirName := filepath.Base(destDir)
 	// Add retry logic to wait for file to be visible to dockerapi's Docker daemon
 	// Use a loop with small delays to check if file exists before attempting extraction
+	// Retry up to 30 times with 0.5s delay (15s total) so large uploads are visible to dockerapi before extraction
 	extractCmd := fmt.Sprintf("sh -c 'apk add --no-cache unzip > /dev/null 2>&1 && cd /workspace && "+
-		"for i in $(seq 1 10); do "+
+		"for i in $(seq 1 30); do "+
 		"if [ -f %s ]; then "+
 		"mkdir -p %s && unzip -q -o %s -d %s && echo \"Extraction successful\" && exit 0; "+
 		"fi; "+
-		"sleep 0.2; "+
+		"sleep 0.5; "+
 		"done; "+
 		"echo \"ERROR: Zip file %s not found in /workspace after retries\"; "+
 		"ls -la /workspace 2>&1; "+

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,6 @@ go 1.24.0
 
 require (
 	github.com/docker/docker v25.0.13+incompatible
-	github.com/globocom/glbgelf v0.0.0-20190310030100-36e52796d86a
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.15.0
 	github.com/lib/pq v1.10.9
@@ -39,7 +38,6 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
@@ -95,7 +93,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260122232226-8e98ce8d340d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260122232226-8e98ce8d340d // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -51,8 +51,6 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/globocom/glbgelf v0.0.0-20190310030100-36e52796d86a h1:4xPuLeesHeiGJkHlUqTDNMt8lsM76UTiheumSY0+NAM=
-github.com/globocom/glbgelf v0.0.0-20190310030100-36e52796d86a/go.mod h1:V9F16sV6PJnoYnOmyswcE8nB/vOyaFPjg/4Ie6q6EyQ=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -71,8 +69,6 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -393,8 +389,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
-gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0 h1:Xg23ydYYJLmb9AK3XdcEpplHZd1MpN3X2ZeeMoBClmY=
-gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0/go.mod h1:CeDeqW4tj9FrgZXF/dQCWZrBdcZWWBenhJtxLH4On2g=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/api/kubernetes/huskykube.go
+++ b/api/kubernetes/huskykube.go
@@ -33,6 +33,11 @@ func configureImagePath(image, tag string) (string, string) {
 
 // KubeRun starts a new pod and returns its output and an error.
 func KubeRun(image, imageTag, cmd, securityTestName, id string, podSchedulingTimeoutInSeconds, timeOutInSeconds int) (string, string, error) {
+	return KubeRunWithVolume(image, imageTag, cmd, securityTestName, id, "", podSchedulingTimeoutInSeconds, timeOutInSeconds)
+}
+
+// KubeRunWithVolume starts a new pod with an optional volume mount and returns its output and an error.
+func KubeRunWithVolume(image, imageTag, cmd, securityTestName, id, volumePath string, podSchedulingTimeoutInSeconds, timeOutInSeconds int) (string, string, error) {
 
 	// step 1: create a new Kubernetes API client
 	k, err := NewKubernetes()
@@ -46,7 +51,7 @@ func KubeRun(image, imageTag, cmd, securityTestName, id string, podSchedulingTim
 	podName := fmt.Sprintf("%s-%s", strings.ToLower(id), securityTestName)
 
 	// step 3: create a new container given an image and it's cmd
-	podUID, err := k.CreatePod(fullContainerImage, cmd, podName, securityTestName)
+	podUID, err := k.CreatePodWithVolume(fullContainerImage, cmd, podName, securityTestName, volumePath)
 	if err != nil {
 		log.Error(logActionRun, logInfoHuskyKube, 5002, fullContainerImage, k.PID, err.Error())
 		return "", "", err

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -15,6 +15,8 @@ var MsgCode = map[int]string{
 	19: "SecurityTest upserted in MondoDB: ",
 	20: "Default User found in MongoDB.",
 	24: "URL received to generate a new token: ",
+	25: "Zip file upload request received: ",
+	26: "Zip file uploaded successfully: ",
 
 	// HuskyCI API warnings
 	101: "Analysis started: ",

--- a/api/routes/analysis.go
+++ b/api/routes/analysis.go
@@ -1,17 +1,24 @@
 package routes
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/huskyci-org/huskyCI/api/analysis"
 	"github.com/huskyci-org/huskyCI/api/auth"
 	apiContext "github.com/huskyci-org/huskyCI/api/context"
+	huskydocker "github.com/huskyci-org/huskyCI/api/dockers"
 	"github.com/huskyci-org/huskyCI/api/log"
 	"github.com/huskyci-org/huskyCI/api/token"
 	"github.com/huskyci-org/huskyCI/api/types"
 	"github.com/huskyci-org/huskyCI/api/util"
+	apiUtil "github.com/huskyci-org/huskyCI/api/util/api"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -40,7 +47,7 @@ const logInfoAnalysis = "ANALYSIS"
 func GetAnalysis(c echo.Context) error {
 
 	RID := c.Param("id")
-	attemptToken := c.Request().Header.Get("Husky-Token")
+	attemptToken := util.GetTokenFromRequest(c)
 
 	if err := util.CheckMaliciousRID(RID, c); err != nil {
 		log.Error(logActionGetAnalysis, logInfoAnalysis, 1017, RID)
@@ -90,15 +97,129 @@ func GetAnalysis(c echo.Context) error {
 	return c.JSON(http.StatusOK, analysisResult)
 }
 
+// UploadZip handles zip file uploads for local repository analysis
+func UploadZip(c echo.Context) error {
+	log.Info("UploadZip", logInfoAnalysis, 25, fmt.Sprintf("RID from query: %s", c.QueryParam("rid")))
+	RID := c.Response().Header().Get(echo.HeaderXRequestID)
+	_ = util.GetTokenFromRequest(c) // Token retrieved for potential future validation
+
+	// Get RID from query parameter or use request ID
+	requestedRID := c.QueryParam("rid")
+	if requestedRID == "" {
+		requestedRID = RID
+	}
+	log.Info("UploadZip", logInfoAnalysis, 25, fmt.Sprintf("Using RID: %s (query: %s, header: %s)", requestedRID, c.QueryParam("rid"), RID))
+
+	if requestedRID == "" {
+		reply := map[string]interface{}{
+			"success": false,
+			"error":   "missing RID",
+			"message": "RID parameter is required. Provide it as query parameter 'rid' or it will be generated from request ID.",
+		}
+		return c.JSON(http.StatusBadRequest, reply)
+	}
+
+	// Validate RID format
+	if err := util.CheckMaliciousRID(requestedRID, c); err != nil {
+		log.Error("UploadZip", logInfoAnalysis, 1017, requestedRID)
+		return err
+	}
+
+	// Ensure zip storage directory exists
+	if err := util.EnsureZipStorageDir(); err != nil {
+		log.Error("UploadZip", logInfoAnalysis, 1019, err)
+		reply := map[string]interface{}{
+			"success": false,
+			"error":   "internal server error",
+			"message": "Failed to initialize zip storage directory.",
+		}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+
+	// Get uploaded file
+	file, err := c.FormFile("zipfile")
+	if err != nil {
+		log.Error("UploadZip", logInfoAnalysis, 1020, err)
+		reply := map[string]interface{}{
+			"success": false,
+			"error":   "invalid request",
+			"message": "No zip file provided. Use multipart/form-data with 'zipfile' field.",
+		}
+		return c.JSON(http.StatusBadRequest, reply)
+	}
+
+	// Validate file extension
+	if filepath.Ext(file.Filename) != ".zip" {
+		reply := map[string]interface{}{
+			"success": false,
+			"error":   "invalid file type",
+			"message": "File must be a .zip archive.",
+		}
+		return c.JSON(http.StatusBadRequest, reply)
+	}
+
+	// Open uploaded file
+	src, err := file.Open()
+	if err != nil {
+		log.Error("UploadZip", logInfoAnalysis, 1021, err)
+		reply := map[string]interface{}{
+			"success": false,
+			"error":   "internal server error",
+			"message": "Failed to open uploaded file.",
+		}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	defer src.Close()
+
+	// Save file
+	zipPath := util.GetZipFilePath(requestedRID)
+	log.Info("UploadZip", logInfoAnalysis, 25, fmt.Sprintf("Saving zip file to: %s", zipPath))
+	dst, err := os.Create(zipPath)
+	if err != nil {
+		log.Error("UploadZip", logInfoAnalysis, 1022, fmt.Sprintf("Failed to create file at %s: %v", zipPath, err))
+		reply := map[string]interface{}{
+			"success": false,
+			"error":   "internal server error",
+			"message": fmt.Sprintf("Failed to save uploaded file to %s: %v", zipPath, err),
+		}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	defer dst.Close()
+
+	if _, err = io.Copy(dst, src); err != nil {
+		log.Error("UploadZip", logInfoAnalysis, 1023, fmt.Sprintf("Failed to copy file content: %v", err))
+		reply := map[string]interface{}{
+			"success": false,
+			"error":   "internal server error",
+			"message": fmt.Sprintf("Failed to save uploaded file: %v", err),
+		}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+
+	log.Info("UploadZip", logInfoAnalysis, 26, fmt.Sprintf("RID: %s, Filename: %s, Path: %s", requestedRID, file.Filename, zipPath))
+
+	reply := map[string]interface{}{
+		"success": true,
+		"error":   "",
+		"message": fmt.Sprintf("Zip file uploaded successfully for RID: %s", requestedRID),
+		"rid":     requestedRID,
+	}
+	return c.JSON(http.StatusCreated, reply)
+}
+
 // ReceiveRequest receives the request and performs several checks before starting a new analysis.
 func ReceiveRequest(c echo.Context) error {
 
 	RID := c.Response().Header().Get(echo.HeaderXRequestID)
-	attemptToken := c.Request().Header.Get("Husky-Token")
+	attemptToken := util.GetTokenFromRequest(c)
 
 	// step-00: is this a valid JSON?
+	// Read raw body first to handle EnryOutput binding
+	bodyBytes, _ := io.ReadAll(c.Request().Body)
+	c.Request().Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	
 	repository := types.Repository{}
-	err := c.Bind(&repository)
+	err := json.Unmarshal(bodyBytes, &repository)
 	if err != nil {
 		log.Error(logActionReceiveRequest, logInfoAnalysis, 1015, err)
 		reply := map[string]interface{}{
@@ -123,6 +244,69 @@ func ReceiveRequest(c echo.Context) error {
 		return err
 	}
 	repository.URL = sanitizedRepoURL
+
+	// step-01a: If this is a file:// URL, verify the zip file exists
+	if util.IsFileURL(repository.URL) {
+		log.Info(logActionReceiveRequest, logInfoAnalysis, 26, fmt.Sprintf("Processing file:// URL: %s", repository.URL))
+		extractedRID := util.ExtractRIDFromFileURL(repository.URL)
+		if extractedRID == "" {
+			reply := map[string]interface{}{
+				"success": false,
+				"error":   "invalid file URL",
+				"message": "Invalid file:// URL format. Expected format: file://<RID>",
+			}
+			return c.JSON(http.StatusBadRequest, reply)
+		}
+		zipPath := util.GetZipFilePath(extractedRID)
+		if _, err := os.Stat(zipPath); os.IsNotExist(err) {
+			reply := map[string]interface{}{
+				"success": false,
+				"error":   "zip file not found",
+				"message": fmt.Sprintf("Zip file for RID '%s' not found. Please upload the zip file first using POST /analysis/upload", extractedRID),
+			}
+			return c.JSON(http.StatusBadRequest, reply)
+		}
+		// Extract the zip file if not already extracted in API container
+		extractedDir := util.GetExtractedDir(extractedRID)
+		if _, err := os.Stat(extractedDir); os.IsNotExist(err) {
+			// Extract in API container first (for API's own use)
+			if err := util.ExtractZip(zipPath, extractedDir); err != nil {
+				log.Error(logActionReceiveRequest, logInfoAnalysis, 1018, err)
+				reply := map[string]interface{}{
+					"success": false,
+					"error":   "failed to extract zip file",
+					"message": fmt.Sprintf("Failed to extract zip file: %v", err),
+				}
+				return c.JSON(http.StatusInternalServerError, reply)
+			}
+		}
+		
+		// Always extract in dockerapi to ensure dockerapi's Docker daemon can see the files
+		// This is necessary because docker-in-docker doesn't properly share bind mounts
+		// Even if files exist in API container, dockerapi can't see them
+		if os.Getenv("HUSKYCI_INFRASTRUCTURE_USE") == "docker" {
+			log.Info(logActionReceiveRequest, logInfoAnalysis, 26, fmt.Sprintf("Attempting to extract zip in dockerapi for RID: %s", extractedRID))
+			dockerAPIHost, err := apiContext.APIConfiguration.DBInstance.FindAndModifyDockerAPIAddresses()
+			if err != nil {
+				log.Error(logActionReceiveRequest, logInfoAnalysis, 1018, fmt.Errorf("failed to get dockerapi host (non-fatal): %v", err))
+			} else {
+				apiHost, err := apiUtil.FormatDockerHostAddress(dockerAPIHost, apiContext.APIConfiguration)
+				if err != nil {
+					log.Error(logActionReceiveRequest, logInfoAnalysis, 1018, fmt.Errorf("failed to format dockerapi host (non-fatal): %v", err))
+				} else {
+					log.Info(logActionReceiveRequest, logInfoAnalysis, 26, fmt.Sprintf("Extracting zip in dockerapi: zipPath=%s, destDir=%s", zipPath, extractedDir))
+					// Extract files in dockerapi using a temporary container
+					// This ensures dockerapi can see the files even if they already exist in API container
+					if err := huskydocker.ExtractZipInDockerAPI(apiHost, zipPath, extractedDir); err != nil {
+						// Log but don't fail - extraction in API container may have succeeded
+						log.Error(logActionReceiveRequest, logInfoAnalysis, 1018, fmt.Errorf("failed to extract zip in dockerapi (non-fatal): %v", err))
+					} else {
+						log.Info(logActionReceiveRequest, logInfoAnalysis, 26, fmt.Sprintf("Successfully extracted zip in dockerapi for RID: %s", extractedRID))
+					}
+				}
+			}
+		}
+	}
 
 	// step-02: is this repository already in MongoDB?
 	repositoryQuery := map[string]interface{}{"repositoryURL": repository.URL}
@@ -185,6 +369,19 @@ func ReceiveRequest(c echo.Context) error {
 
 	// step 04: lets start this analysis!
 	log.Info(logActionReceiveRequest, logInfoAnalysis, 16, repository.Branch, repository.URL)
+	// Debug: Log EnryOutput if present
+	if util.IsFileURL(repository.URL) {
+		enryOutputMsg := fmt.Sprintf("Received file:// URL: %s, EnryOutput present: %v, length: %d", repository.URL, repository.EnryOutput != "", len(repository.EnryOutput))
+		log.Info(logActionReceiveRequest, logInfoAnalysis, 16, enryOutputMsg)
+		if repository.EnryOutput != "" {
+			preview := repository.EnryOutput
+			if len(preview) > 200 {
+				preview = preview[:200] + "..."
+			}
+			log.Info(logActionReceiveRequest, logInfoAnalysis, 16, fmt.Sprintf("EnryOutput preview: %s", preview))
+		}
+	}
+	
 	go analysis.StartAnalysis(RID, repository)
 	reply := map[string]interface{}{
 		"success": true,

--- a/api/routes/analysis.go
+++ b/api/routes/analysis.go
@@ -88,12 +88,7 @@ func GetAnalysis(c echo.Context) error {
 		return c.JSON(http.StatusUnauthorized, reply)
 	}
 
-	// Log the successful retrieval of analysis data
 	log.Info(logActionGetAnalysis, logInfoAnalysis, 113, "Analysis data retrieved successfully for RID:", RID)
-
-	// Add logging to capture the analysis result being returned
-	log.Info(logActionGetAnalysis, logInfoAnalysis, 113, "Analysis result:", analysisResult)
-
 	return c.JSON(http.StatusOK, analysisResult)
 }
 
@@ -381,7 +376,6 @@ func ReceiveRequest(c echo.Context) error {
 			log.Info(logActionReceiveRequest, logInfoAnalysis, 16, fmt.Sprintf("EnryOutput preview: %s", preview))
 		}
 	}
-	
 	go analysis.StartAnalysis(RID, repository)
 	reply := map[string]interface{}{
 		"success": true,

--- a/api/securitytest/enry.go
+++ b/api/securitytest/enry.go
@@ -3,6 +3,7 @@ package securitytest
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/huskyci-org/huskyCI/api/log"
@@ -33,11 +34,23 @@ func analyzeEnry(enryScan *SecTestScanInfo) error {
 func (enryScan *SecTestScanInfo) prepareEnryOutput() error {
 	repositoryLanguages := []types.Code{}
 	mapLanguages := make(map[string][]interface{})
+	
+	// Log the raw enry output for debugging
+	outputPreview := enryScan.Container.COutput
+	if len(outputPreview) > 500 {
+		outputPreview = outputPreview[:500] + "..."
+	}
+	log.Info("prepareEnryOutput", "ENRY", 16, fmt.Sprintf("Enry raw output (first 500 chars): %s", outputPreview))
+	
 	err := json.Unmarshal([]byte(enryScan.Container.COutput), &mapLanguages)
 	if err != nil {
 		log.Error("prepareEnryOutput", "ENRY", 1003, enryScan.Container.COutput, err)
 		return err
 	}
+	
+	// Log parsed languages for debugging
+	log.Info("prepareEnryOutput", "ENRY", 16, fmt.Sprintf("Parsed %d languages from enry output", len(mapLanguages)))
+	
 	for name, files := range mapLanguages {
 		fs := []string{}
 		for _, f := range files {
@@ -56,9 +69,65 @@ func (enryScan *SecTestScanInfo) prepareEnryOutput() error {
 				Files:    fs,
 			}
 			repositoryLanguages = append(repositoryLanguages, newLanguage)
+			log.Info("prepareEnryOutput", "ENRY", 16, fmt.Sprintf("Added language: %s with %d files", name, len(fs)))
+		} else {
+			log.Info("prepareEnryOutput", "ENRY", 16, fmt.Sprintf("Skipped excluded language: %s", name))
 		}
 	}
 
 	enryScan.Codes = repositoryLanguages
+	log.Info("prepareEnryOutput", "ENRY", 16, fmt.Sprintf("Final Codes count: %d", len(enryScan.Codes)))
 	return nil
+}
+
+// ParseProvidedEnryOutput parses Enry JSON output provided by CLI and populates enryScan.Codes
+// This is used for file:// URLs to avoid docker-in-docker issues
+func (enryScan *SecTestScanInfo) ParseProvidedEnryOutput(enryOutputJSON string, languageExclusions map[string]bool) error {
+	repositoryLanguages := []types.Code{}
+	mapLanguages := make(map[string][]interface{})
+	
+	log.Info("parseProvidedEnryOutput", "ENRY", 16, fmt.Sprintf("Parsing provided Enry output (first 500 chars): %s", enryOutputJSON[:min(500, len(enryOutputJSON))]))
+	
+	err := json.Unmarshal([]byte(enryOutputJSON), &mapLanguages)
+	if err != nil {
+		log.Error("parseProvidedEnryOutput", "ENRY", 1003, enryOutputJSON, err)
+		return err
+	}
+	
+	log.Info("parseProvidedEnryOutput", "ENRY", 16, fmt.Sprintf("Parsed %d languages from provided Enry output", len(mapLanguages)))
+	
+	for name, files := range mapLanguages {
+		fs := []string{}
+		for _, f := range files {
+			if reflect.TypeOf(f).String() == "string" {
+				fs = append(fs, f.(string))
+			} else {
+				errMsg := errors.New("error mapping languages")
+				log.Error("parseProvidedEnryOutput", "ENRY", 1032, errMsg)
+				return errMsg
+			}
+		}
+
+		if !languageExclusions[name] {
+			newLanguage := types.Code{
+				Language: name,
+				Files:    fs,
+			}
+			repositoryLanguages = append(repositoryLanguages, newLanguage)
+			log.Info("parseProvidedEnryOutput", "ENRY", 16, fmt.Sprintf("Added language: %s with %d files", name, len(fs)))
+		} else {
+			log.Info("parseProvidedEnryOutput", "ENRY", 16, fmt.Sprintf("Skipped excluded language: %s", name))
+		}
+	}
+
+	enryScan.Codes = repositoryLanguages
+	log.Info("parseProvidedEnryOutput", "ENRY", 16, fmt.Sprintf("Final Codes count: %d", len(enryScan.Codes)))
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/api/securitytest/gitauthors.go
+++ b/api/securitytest/gitauthors.go
@@ -2,6 +2,7 @@ package securitytest
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/huskyci-org/huskyCI/api/log"
 	"github.com/huskyci-org/huskyCI/api/util"
@@ -17,8 +18,23 @@ func analyzeGitAuthors(gitAuthorsScan *SecTestScanInfo) error {
 	gitAuthorsOutput := GitAuthorsOutput{}
 	gitAuthorsScan.FinalOutput = gitAuthorsOutput
 
-	// Unmarshall rawOutput into finalOutput, that is a GitAuthors struct.
+	output := strings.TrimSpace(gitAuthorsScan.Container.COutput)
+	// Empty or invalid JSON (e.g. from file:// with no git history): treat as no authors, do not fail analysis
+	if output == "" {
+		gitAuthorsScan.CommitAuthorsNotFound = true
+		gitAuthorsScan.CommitAuthors = gitAuthorsOutput
+		gitAuthorsScan.prepareContainerAfterScan()
+		return nil
+	}
 	if err := json.Unmarshal([]byte(gitAuthorsScan.Container.COutput), &gitAuthorsOutput); err != nil {
+		// For empty/invalid JSON, treat as no authors so analysis can complete (e.g. file:// has no git)
+		if strings.Contains(err.Error(), "unexpected end of JSON input") || strings.Contains(err.Error(), "EOF") {
+			log.Info("analyzeGitAuthors", "GITAUTHORS", 16, "GitAuthors output empty or invalid JSON, treating as no authors")
+			gitAuthorsScan.CommitAuthorsNotFound = true
+			gitAuthorsScan.CommitAuthors = gitAuthorsOutput
+			gitAuthorsScan.prepareContainerAfterScan()
+			return nil
+		}
 		log.Error("analyzeGitAuthors", "GITAUTHORS", 1035, gitAuthorsScan.Container.COutput, err)
 		gitAuthorsScan.ErrorFound = util.HandleScanError(gitAuthorsScan.Container.COutput, err)
 		gitAuthorsScan.prepareContainerAfterScan()

--- a/api/server.go
+++ b/api/server.go
@@ -72,6 +72,7 @@ func main() {
 
 	// analysis routes
 	echoInstance.POST("/analysis", routes.ReceiveRequest)
+	echoInstance.POST("/analysis/upload", routes.UploadZip)
 	echoInstance.GET("/analysis/:id", routes.GetAnalysis)
 	// echoInstance.PUT("/analysis/:id", routes.UpdateAnalysis)
 	// echoInstance.DELETE("/analysis/:id", routes.DeleteAnalysis)

--- a/api/token/generator.go
+++ b/api/token/generator.go
@@ -12,7 +12,12 @@ import (
 )
 
 // ValidateURL validates if an URL is malicious or not.
+// If the URL is empty, it returns an empty string without error to allow generic tokens.
 func (tC *TCaller) ValidateURL(url string) (string, error) {
+	// Allow empty URL for generic tokens that work with any repository
+	if url == "" {
+		return "", nil
+	}
 	return util.CheckMaliciousRepoURL(url)
 }
 
@@ -44,7 +49,8 @@ func (tC *TCaller) FindAccessToken(ID string) (types.DBToken, error) {
 	return apiContext.APIConfiguration.DBInstance.FindOneDBAccessToken(aTokenQuery)
 }
 
-// FindRepoURL checks if a Access TOken is present based on a given URL.
+// FindRepoURL checks if an Access Token is present based on a given URL.
+// If repositoryURL is empty, it searches for generic tokens (tokens with empty URL).
 func (tC *TCaller) FindRepoURL(repositoryURL string) error {
 	repoQuery := map[string]interface{}{"repositoryURL": repositoryURL, "isValid": true}
 	_, err := apiContext.APIConfiguration.DBInstance.FindOneDBAccessToken(repoQuery)

--- a/api/token/tokenvalidator.go
+++ b/api/token/tokenvalidator.go
@@ -1,11 +1,20 @@
 package token
 
+import (
+	"github.com/huskyci-org/huskyCI/api/util"
+)
+
 // HasAuthorization will verify if exists a valid
 // access token for the given repository. If exists,
 // it will validate the received access token. A true
 // bool is returned if it has authorization. If not,
 // it will return false.
 func (tV TValidator) HasAuthorization(accessToken, repositoryURL string) bool {
+	// Local file analysis (file://) does not require token authentication.
+	// The URL is file://<RID> from CLI zip uploads; no repository secret is at stake.
+	if util.IsFileURL(repositoryURL) {
+		return true
+	}
 	// Temporary: Verify if exists an access token
 	// for that repo
 	if err := tV.TokenVerifier.VerifyRepo(repositoryURL); err != nil {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -9,6 +9,7 @@ type Repository struct {
 	URL                string          `bson:"repositoryURL" json:"repositoryURL"`
 	Branch             string          `json:"repositoryBranch"`
 	LanguageExclusions map[string]bool `json:"languageExclusions"`
+	EnryOutput         string          `bson:"enryOutput,omitempty" json:"enryOutput,omitempty"` // Optional: Enry JSON output from CLI for file:// URLs
 	CreatedAt          time.Time       `bson:"createdAt" json:"createdAt"`
 }
 

--- a/api/util/api/api.go
+++ b/api/util/api/api.go
@@ -3,7 +3,9 @@ package util
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	apiContext "github.com/huskyci-org/huskyCI/api/context"
@@ -188,29 +190,62 @@ func (cH *CheckUtils) checkDefaultUser(configAPI *apiContext.APIConfig) error {
 }
 
 // formatDockerHost formats a Docker host address, handling both Unix sockets and TCP addresses.
+// It ensures unix paths are never URL-encoded in the result, so the Docker client does not
+// mis-parse them as HTTPS (e.g. "unix://%2Fvar%2Frun%2Fdocker.sock" → "unix:///var/run/docker.sock").
 func formatDockerHost(address string, port int) string {
-	// Check if address is already a Unix socket path (starts with unix:// or /)
+	address = strings.TrimSpace(address)
+	// Decode URL-encoded path so we never treat a path as a TCP host (e.g. %2Fvar%2Frun%2Fdocker.sock)
+	if decoded, err := url.PathUnescape(address); err == nil && decoded != address {
+		if strings.HasPrefix(decoded, "unix://") || strings.HasPrefix(decoded, "/") {
+			address = decoded
+		}
+	}
+	// Normalize unix:// URLs: decode path so client gets unix:///var/run/docker.sock, not unix://%2Fvar%2Frun%2Fdocker.sock
 	if strings.HasPrefix(address, "unix://") {
-		return address
+		path := strings.TrimPrefix(address, "unix://")
+		if pathDecoded, err := url.PathUnescape(path); err == nil {
+			path = pathDecoded
+		}
+		return "unix://" + path
 	}
 	if strings.HasPrefix(address, "/") {
-		// Format Unix socket path with unix:// prefix (triple slash for absolute path)
 		return fmt.Sprintf("unix://%s", address)
 	}
-	
-	// For TCP addresses, format as https://host:port
+	// For TCP addresses, format as https://host:port (dind serves TLS on 2376; use DOCKER_TLS_VERIFY=0 to skip cert verification)
 	return fmt.Sprintf("https://%s:%d", address, port)
 }
 
 // FormatDockerHostAddress formats the Docker host address based on the current host index.
+// When HUSKYCI_DOCKERAPI_ADDR is set to a TCP host (e.g. dockerapi), that value is always
+// used so Docker-in-Docker works even if the DB has a unix socket path or empty host.
 func FormatDockerHostAddress(dockerHost types.DockerAPIAddresses, configAPI *apiContext.APIConfig) (string, error) {
+	port := 2376
+	configAddr := ""
+	if configAPI != nil && configAPI.DockerHostsConfig != nil {
+		port = configAPI.DockerHostsConfig.DockerAPIPort
+		configAddr = strings.TrimSpace(configAPI.DockerHostsConfig.Address)
+	}
+	if configAddr == "" {
+		configAddr = strings.TrimSpace(os.Getenv("HUSKYCI_DOCKERAPI_ADDR"))
+		if p := os.Getenv("HUSKYCI_DOCKERAPI_PORT"); p != "" {
+			if portNum, err := strconv.Atoi(p); err == nil {
+				port = portNum
+			}
+		}
+	}
+	// Prefer configured TCP host when set (e.g. dockerapi in Docker Compose)
+	if configAddr != "" && !strings.HasPrefix(configAddr, "/") && !strings.HasPrefix(configAddr, "unix://") {
+		return formatDockerHost(configAddr, port), nil
+	}
 	if len(dockerHost.HostList) == 0 {
 		return "", errors.New("Docker host list is empty")
 	}
 	hostIndex := dockerHost.CurrentHostIndex % len(dockerHost.HostList)
-	host := dockerHost.HostList[hostIndex]
-	
-	return formatDockerHost(host, configAPI.DockerHostsConfig.DockerAPIPort), nil
+	host := strings.TrimSpace(dockerHost.HostList[hostIndex])
+	if host == "" {
+		return "", errors.New("Docker host list contains empty host")
+	}
+	return formatDockerHost(host, port), nil
 }
 
 func checkSecurityTest(securityTestName string, configAPI *apiContext.APIConfig) error {

--- a/api/util/api/api_suite_test.go
+++ b/api/util/api/api_suite_test.go
@@ -17,8 +17,8 @@ func TestApi(t *testing.T) {
 func TestInitLog(t *testing.T) {
 	log.InitLog(true, "", "", "log_test", "log_test")
 
-	if log.Logger == nil {
-		t.Error("expected logger to be initialized, but it wasn't")
+	if log.DefaultLogger() == nil {
+		t.Error("expected default logger to be initialized, but it wasn't")
 		return
 	}
 }

--- a/api/util/api/api_test.go
+++ b/api/util/api/api_test.go
@@ -3,8 +3,8 @@ package util_test
 import (
 	"errors"
 
-	"github.com/globocom/glbgelf"
 	apiContext "github.com/huskyci-org/huskyCI/api/context"
+	"github.com/huskyci-org/huskyCI/api/log"
 	apiUtil "github.com/huskyci-org/huskyCI/api/util/api"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,7 +33,7 @@ var checkHuskyTests = []CheckHuskyData{
 }
 
 var _ = Describe("Util API", func() {
-	glbgelf.InitLogger("", "huskytest", "", true, "UDP")
+	log.InitLog(true, "", "", "huskytest", "huskytest")
 	Describe("CheckHuskyRequirements", func() {
 		Context("When checkEnvVars returns an error", func() {
 			fakeCheck := &apiUtil.FakeCheck{

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -151,6 +151,12 @@ func RemoveDuplicates(s []string) []string {
 
 // HandleScanError show the right error when json is not expected as output of scan
 func HandleScanError(containerOutput string, otherErr error) error {
+	if otherErr != nil && (strings.Contains(otherErr.Error(), "unexpected end of JSON input") || strings.Contains(otherErr.Error(), "EOF")) {
+		trimmed := strings.TrimSpace(containerOutput)
+		if trimmed == "" {
+			return fmt.Errorf("security tool produced no valid JSON output (empty or truncated). This may mean the tool had no code to analyze (e.g. zip extraction in dockerapi failed or workspace was empty): %w", otherErr)
+		}
+	}
 	return fmt.Errorf("%s\nerror from top: %v", containerOutput, otherErr)
 }
 

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -31,8 +31,43 @@ const (
 )
 
 // HandleCmd will extract %GIT_REPO%, %GIT_BRANCH% from cmd and replace it with the proper repository URL.
+// For file:// URLs, it replaces git clone commands with commands to use the mounted volume at /workspace.
 func HandleCmd(repositoryURL, repositoryBranch, cmd string) string {
 	if repositoryURL != "" && repositoryBranch != "" && cmd != "" {
+		// Check if this is a file:// URL (local repository)
+		if IsFileURL(repositoryURL) {
+			// Replace git clone commands with commands to copy from mounted volume
+			// The volume is mounted at /workspace in the container
+			// Handle various git clone patterns that may have prefixes/suffixes
+			
+			// Pattern 1: git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code (with optional prefix/suffix)
+			// Match the entire line containing this pattern (handles GIT_TERMINAL_PROMPT=0 prefix, --quiet suffix, etc.)
+			// Use cp -r /workspace/. code to copy contents (not the directory itself), or cp -r /workspace/* code
+			re1 := regexp.MustCompile(`(?m)^[^\n]*git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code[^\n]*$`)
+			if re1.MatchString(cmd) {
+				// Copy contents of /workspace into code directory
+				cmd = re1.ReplaceAllString(cmd, "mkdir -p code && cp -r /workspace/. code/ 2>/dev/null || cp -r /workspace/* code/")
+			}
+			
+			// Pattern 2: git clone %GIT_REPO% code (with optional prefix/suffix)
+			re2 := regexp.MustCompile(`(?m)^[^\n]*git clone %GIT_REPO% code[^\n]*$`)
+			if re2.MatchString(cmd) && !strings.Contains(cmd, "cp -r /workspace") {
+				cmd = re2.ReplaceAllString(cmd, "mkdir -p code && cp -r /workspace/. code/ 2>/dev/null || cp -r /workspace/* code/")
+			}
+			
+			// Pattern 3: Fallback - any git clone with %GIT_REPO% that wasn't caught above
+			if strings.Contains(cmd, "git clone") && strings.Contains(cmd, "%GIT_REPO%") && !strings.Contains(cmd, "cp -r /workspace") {
+				// Match any line containing git clone with %GIT_REPO% and code
+				re3 := regexp.MustCompile(`(?m)^[^\n]*git clone[^\n]*%GIT_REPO%[^\n]*code[^\n]*$`)
+				cmd = re3.ReplaceAllString(cmd, "mkdir -p code && cp -r /workspace/. code/ 2>/dev/null || cp -r /workspace/* code/")
+			}
+			
+			// Remove remaining placeholders since we're using extracted files
+			cmd = strings.Replace(cmd, "%GIT_BRANCH%", repositoryBranch, -1)
+			cmd = strings.Replace(cmd, "%GIT_REPO%", repositoryURL, -1)
+			return cmd
+		}
+		// Standard git repository handling
 		replace1 := strings.Replace(cmd, "%GIT_REPO%", repositoryURL, -1)
 		replace2 := strings.Replace(replace1, "%GIT_BRANCH%", repositoryBranch, -1)
 		return replace2
@@ -150,7 +185,16 @@ func CheckValidInput(repository types.Repository, c echo.Context) (string, error
 }
 
 // CheckMaliciousRepoURL verifies if a given URL is a git repository and returns the sanitizied string and its error
+// It accepts both git repository URLs (ending in .git) and file:// URLs for local analysis
 func CheckMaliciousRepoURL(repositoryURL string) (string, error) {
+	// Check for file:// URLs (for local file analysis)
+	regexpFile := `file://[a-zA-Z0-9\-_/\.]+`
+	rFile := regexp.MustCompile(regexpFile)
+	if rFile.MatchString(repositoryURL) {
+		return rFile.FindString(repositoryURL), nil
+	}
+	
+	// Check for git repository URLs (must end in .git)
 	regexpGit := `((git|ssh|http(s)?)|((git@|gitlab@)[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?`
 	r := regexp.MustCompile(regexpGit)
 	valid, err := regexp.MatchString(regexpGit, repositoryURL)
@@ -274,4 +318,46 @@ func SliceContains(slice []string, str string) bool {
 		}
 	}
 	return false
+}
+
+// GetTokenFromRequest retrieves the authentication token from the request.
+// It first checks the "Husky-Token" header. If the header is empty,
+// it checks environment variables based on the request source:
+// - HUSKYCI_CLI_TOKEN for CLI requests (detected via User-Agent containing "huskyci-cli")
+// - HUSKYCI_CLIENT_TOKEN for client requests (detected via User-Agent containing "huskyci-client")
+// Returns empty string if no token is found.
+func GetTokenFromRequest(c echo.Context) string {
+	// First, check the Husky-Token header
+	token := c.Request().Header.Get("Husky-Token")
+	if token != "" {
+		return token
+	}
+
+	// If header is empty, check User-Agent to determine source
+	userAgent := c.Request().Header.Get("User-Agent")
+	
+	// Check if it's a CLI request
+	if strings.Contains(strings.ToLower(userAgent), "huskyci-cli") {
+		if cliToken := os.Getenv("HUSKYCI_CLI_TOKEN"); cliToken != "" {
+			return cliToken
+		}
+	}
+	
+	// Check if it's a client request
+	if strings.Contains(strings.ToLower(userAgent), "huskyci-client") {
+		if clientToken := os.Getenv("HUSKYCI_CLIENT_TOKEN"); clientToken != "" {
+			return clientToken
+		}
+	}
+	
+	// Fallback: if User-Agent is not set or doesn't match, try both environment variables
+	// CLI token takes precedence
+	if cliToken := os.Getenv("HUSKYCI_CLI_TOKEN"); cliToken != "" {
+		return cliToken
+	}
+	if clientToken := os.Getenv("HUSKYCI_CLIENT_TOKEN"); clientToken != "" {
+		return clientToken
+	}
+	
+	return ""
 }

--- a/api/util/zip.go
+++ b/api/util/zip.go
@@ -1,0 +1,127 @@
+package util
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// ZipStorageDir is the directory where uploaded zip files are stored
+	ZipStorageDir = "/tmp/huskyci-zips"
+)
+
+// EnsureZipStorageDir creates the zip storage directory if it doesn't exist
+func EnsureZipStorageDir() error {
+	if err := os.MkdirAll(ZipStorageDir, 0755); err != nil {
+		return fmt.Errorf("failed to create zip storage directory: %w", err)
+	}
+	return nil
+}
+
+// GetZipFilePath returns the path where a zip file for a given RID should be stored
+func GetZipFilePath(RID string) string {
+	return filepath.Join(ZipStorageDir, fmt.Sprintf("%s.zip", RID))
+}
+
+// ExtractZip extracts a zip file to a destination directory
+func ExtractZip(zipPath, destDir string) error {
+	// Create destination directory
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	// Open zip file
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to open zip file: %w", err)
+	}
+	defer r.Close()
+
+	// Extract files
+	for _, f := range r.File {
+		err := extractFile(f, destDir)
+		if err != nil {
+			return fmt.Errorf("failed to extract file %s: %w", f.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// extractFile extracts a single file from the zip archive
+func extractFile(f *zip.File, destDir string) error {
+	// Sanitize file path to prevent path traversal
+	path := filepath.Join(destDir, f.Name)
+	
+	// Check for path traversal attempts
+	if !strings.HasPrefix(filepath.Clean(path), filepath.Clean(destDir)+string(os.PathSeparator)) {
+		return fmt.Errorf("illegal file path: %s", f.Name)
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	// Create parent directories
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	// Create file
+	outFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	// Copy file contents
+	_, err = io.Copy(outFile, rc)
+	return err
+}
+
+// CleanupZip removes a zip file and its extracted directory
+func CleanupZip(RID string) error {
+	zipPath := GetZipFilePath(RID)
+	extractedDir := filepath.Join(ZipStorageDir, RID)
+
+	// Remove zip file
+	if err := os.Remove(zipPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove zip file: %w", err)
+	}
+
+	// Remove extracted directory
+	if err := os.RemoveAll(extractedDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove extracted directory: %w", err)
+	}
+
+	return nil
+}
+
+// GetExtractedDir returns the path where a zip file for a given RID should be extracted
+func GetExtractedDir(RID string) string {
+	return filepath.Join(ZipStorageDir, RID)
+}
+
+// IsFileURL checks if a URL is a file:// URL
+func IsFileURL(url string) bool {
+	return strings.HasPrefix(url, "file://")
+}
+
+// ExtractRIDFromFileURL extracts the RID from a file:// URL
+func ExtractRIDFromFileURL(url string) string {
+	if !IsFileURL(url) {
+		return ""
+	}
+	// file://<RID> -> extract RID
+	parts := strings.Split(url, "://")
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}

--- a/cli/analysis/analysis.go
+++ b/cli/analysis/analysis.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -39,6 +41,7 @@ type Analysis struct {
 	CompressedFile  CompressedFile                `bson:"compressedFile" json:"compressedFile"`
 	Errors          []string                      `bson:"errorsFound,omitempty" json:"errorsFound"`
 	Languages       []string                      `bson:"languages" json:"languages"`
+	Path            string                        `json:"-"` // Path being analyzed (for Enry generation)
 	StartedAt       time.Time                     `bson:"startedAt" json:"startedAt"`
 	FinishedAt      time.Time                     `bson:"finishedAt" json:"finishedAt"`
 	Vulnerabilities []vulnerability.Vulnerability `bson:"vulnerabilities" json:"vulnerabilities"`
@@ -83,6 +86,9 @@ func (a *Analysis) CheckPath(path string) error {
 	}
 
 	fmt.Printf("🔍 Scanning code from: %s\n", fullPath)
+
+	// Store path for later use (e.g., Enry output generation)
+	a.Path = fullPath
 
 	if err := a.setLanguages(fullPath); err != nil {
 		if err.Error() == "no languages found" {
@@ -153,19 +159,19 @@ func (a *Analysis) CompressFiles(path string) error {
 // SendZip will send the zip file to the huskyCI API to start the analysis
 func (a *Analysis) SendZip() error {
 	fmt.Println("\n🚀 Sending code to huskyCI API...")
-	
+
 	// Get API target configuration
 	target, err := config.GetCurrentTarget()
 	if err != nil {
 		return fmt.Errorf("failed to get API target configuration: %w\n\nTip: Configure a target using 'huskyci target-add <name> <endpoint>'", err)
 	}
-	
+
 	if target.Token == "" {
-		return fmt.Errorf("authentication token not found\n\nTip: Set HUSKYCI_CLIENT_TOKEN environment variable or configure token storage")
+		return fmt.Errorf("authentication token not found\n\nTip: Set HUSKYCI_CLI_TOKEN environment variable or configure token storage")
 	}
-	
+
 	a.APITarget = target
-	
+
 	if IsVerbose() {
 		zipFilePath, err := config.GetHuskyZipFilePath()
 		if err == nil {
@@ -174,66 +180,202 @@ func (a *Analysis) SendZip() error {
 		fmt.Printf("[VERBOSE] Analysis ID: %s\n", a.ID)
 		fmt.Printf("[VERBOSE] API endpoint: %s\n", target.Endpoint)
 	}
-	
+
 	// Create HTTP client
 	useTLS := util.IsHTTPS(target.Endpoint)
 	httpClient, err := util.NewHTTPClient(useTLS)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP client: %w", err)
 	}
+
+	// For local file analysis, upload the zip file first
+	zipFilePath, err := config.GetHuskyZipFilePath()
+	if err != nil {
+		return fmt.Errorf("failed to get zip file path: %w", err)
+	}
+
+	// Upload zip file for local analysis
+	fmt.Println("📤 Uploading zip file...")
+	if IsVerbose() {
+		fmt.Printf("[VERBOSE] Preparing to upload zip file: %s\n", zipFilePath)
+		fmt.Printf("[VERBOSE] Analysis ID (RID): %s\n", a.ID)
+	}
+	normalizedEndpoint := util.NormalizeURL(target.Endpoint)
+	uploadURL := fmt.Sprintf("%s/analysis/upload?rid=%s", normalizedEndpoint, a.ID)
 	
-	// Prepare request payload
-	// Note: The API currently expects a git repository URL, not a zip file
-	// For local analysis, we use a file:// URL as a workaround
-	// TODO: Implement proper zip file upload endpoint in API
-	requestPayload := types.JSONPayload{
-		RepositoryURL:      fmt.Sprintf("file://%s", a.ID), // Using analysis ID as identifier
-		RepositoryBranch:    "local",
-		LanguageExclusions: make(map[string]bool),
+	if IsVerbose() {
+		fmt.Printf("[VERBOSE] Upload URL: %s\n", uploadURL)
 	}
 	
+	zipFile, err := os.Open(zipFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open zip file: %w", err)
+	}
+	defer zipFile.Close()
+	
+	if IsVerbose() {
+		fileInfo, _ := zipFile.Stat()
+		fmt.Printf("[VERBOSE] Zip file opened successfully, size: %d bytes\n", fileInfo.Size())
+	}
+
+	var uploadBody bytes.Buffer
+	writer := multipart.NewWriter(&uploadBody)
+	part, err := writer.CreateFormFile("zipfile", filepath.Base(zipFilePath))
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+	
+	if _, err := io.Copy(part, zipFile); err != nil {
+		return fmt.Errorf("failed to copy file content: %w", err)
+	}
+	writer.Close()
+
+	uploadReq, err := http.NewRequest("POST", uploadURL, &uploadBody)
+	if err != nil {
+		return fmt.Errorf("failed to create upload request: %w", err)
+	}
+	uploadReq.Header.Set("Content-Type", writer.FormDataContentType())
+	uploadReq.Header.Add("Husky-Token", target.Token)
+	uploadReq.Header.Add("User-Agent", "huskyci-cli")
+
+	if IsVerbose() {
+		fmt.Printf("[VERBOSE] Sending upload request to: %s\n", uploadURL)
+		fmt.Printf("[VERBOSE] Content-Type: %s\n", writer.FormDataContentType())
+		fmt.Printf("[VERBOSE] Upload body size: %d bytes\n", uploadBody.Len())
+	}
+
+	uploadResp, err := httpClient.Do(uploadReq)
+	if err != nil {
+		return fmt.Errorf("failed to upload zip file: %w\n\nTip: Check your network connection and verify the API endpoint is accessible", err)
+	}
+	defer uploadResp.Body.Close()
+
+	if IsVerbose() {
+		fmt.Printf("[VERBOSE] Upload response status: %d\n", uploadResp.StatusCode)
+	}
+
+	uploadBodyBytes, _ := io.ReadAll(uploadResp.Body)
+	if uploadResp.StatusCode != http.StatusCreated {
+		if IsVerbose() {
+			fmt.Printf("[VERBOSE] Upload failed, response: %s\n", string(uploadBodyBytes))
+		}
+		return fmt.Errorf("failed to upload zip file\n\nStatus Code: %d\nResponse: %s\n\nTip: Verify the API supports zip file uploads", uploadResp.StatusCode, string(uploadBodyBytes))
+	}
+
+	// Verify the upload response contains the correct RID
+	var uploadRespData map[string]interface{}
+	if err := json.Unmarshal(uploadBodyBytes, &uploadRespData); err == nil {
+		if respRID, ok := uploadRespData["rid"].(string); ok && respRID != "" {
+			if respRID != a.ID {
+				if IsVerbose() {
+					fmt.Printf("[VERBOSE] Warning: Upload response RID (%s) differs from expected RID (%s)\n", respRID, a.ID)
+				}
+				// Use the RID from the response if different
+				a.ID = respRID
+			}
+			if IsVerbose() {
+				fmt.Printf("[VERBOSE] Upload confirmed with RID: %s\n", respRID)
+			}
+		}
+	}
+
+	if IsVerbose() {
+		fmt.Printf("[VERBOSE] Zip file uploaded successfully with RID: %s\n", a.ID)
+		fmt.Printf("[VERBOSE] Upload response: %s\n", string(uploadBodyBytes))
+	}
+	fmt.Println("✓ Zip file uploaded successfully!")
+
+	// Generate Enry output locally for file:// URLs
+	// This avoids docker-in-docker issues where Enry can't see extracted files
+	var enryOutput string
+	if a.Path != "" {
+		if IsVerbose() {
+			fmt.Printf("[VERBOSE] Generating Enry output locally from path: %s\n", a.Path)
+		}
+		enryOutput, err = a.generateEnryOutput(a.Path)
+		if err != nil {
+			if IsVerbose() {
+				fmt.Printf("[VERBOSE] Warning: Failed to generate Enry output locally: %v (API will run Enry instead)\n", err)
+			}
+			// Continue without Enry output - API will run Enry
+			enryOutput = ""
+		} else {
+			if IsVerbose() {
+				fmt.Printf("[VERBOSE] Generated Enry output: %s\n", enryOutput)
+			}
+		}
+	}
+	
+	// Prepare request payload for analysis
+	requestPayload := types.JSONPayload{
+		RepositoryURL:      fmt.Sprintf("file://%s", a.ID), // Using analysis ID as identifier
+		RepositoryBranch:   "local",
+		LanguageExclusions: make(map[string]bool),
+		EnryOutput:         enryOutput, // Send Enry output to API
+	}
+
 	marshalPayload, err := json.Marshal(requestPayload)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request payload: %w", err)
 	}
-	
-	// Create POST request
-	apiURL := fmt.Sprintf("%s/analysis", target.Endpoint)
+
+	// Create POST request to start analysis
+	apiURL := fmt.Sprintf("%s/analysis", normalizedEndpoint)
 	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(marshalPayload))
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %w", err)
 	}
-	
+
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Husky-Token", target.Token)
-	
+	req.Header.Add("User-Agent", "huskyci-cli")
+
 	if IsVerbose() {
 		fmt.Printf("[VERBOSE] Sending POST request to: %s\n", apiURL)
 		fmt.Printf("[VERBOSE] Request payload: %s\n", string(marshalPayload))
 	}
-	
+
 	// Send request
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send request to API: %w\n\nTip: Check your network connection and verify the API endpoint is accessible", err)
 	}
 	defer resp.Body.Close()
-	
+
 	body, _ := io.ReadAll(resp.Body)
-	
+
 	if resp.StatusCode != http.StatusCreated {
 		if resp.StatusCode == http.StatusUnauthorized {
 			return fmt.Errorf("authentication failed: The provided token is invalid or expired\n\nTip: Generate a new token using the huskyCI API")
 		}
 		if resp.StatusCode == http.StatusBadRequest {
-			return fmt.Errorf("bad request: Invalid request parameters\n\nStatus: %d\nResponse: %s\n\nTip: The API may not support local file analysis yet. Zip file uploads need to be implemented.", resp.StatusCode, string(body))
+			// Try to extract error message from response
+			var errorResp map[string]interface{}
+			errorMsg := "Invalid request parameters"
+			if err := json.Unmarshal(body, &errorResp); err == nil {
+				if msg, ok := errorResp["message"].(string); ok && msg != "" {
+					errorMsg = msg
+				} else if errStr, ok := errorResp["error"].(string); ok && errStr != "" {
+					errorMsg = errStr
+				}
+			}
+			
+			// Check if this is a file:// URL issue (zip file not found)
+			if strings.Contains(requestPayload.RepositoryURL, "file://") {
+				if strings.Contains(string(body), "zip file not found") || strings.Contains(errorMsg, "zip file not found") {
+					return fmt.Errorf("zip file not found on server\n\nRID used: %s\nStatus: %d\nResponse: %s\n\nPossible causes:\n  1. The zip file upload may have failed silently\n  2. The API server may not have write permissions to /tmp/huskyci-zips\n  3. There may be a mismatch between the upload RID and analysis RID\n\nTroubleshooting:\n  - Run with --verbose flag to see detailed logs\n  - Check API server logs for upload errors\n  - Verify the API server has write access to /tmp/huskyci-zips directory\n  - Try uploading again: huskyci run %s", a.ID, resp.StatusCode, string(body), a.ID)
+				}
+				return fmt.Errorf("local file analysis error\n\nRID: %s\nStatus: %d\nResponse: %s\n\nTip: The zip file was uploaded but the analysis request failed. Check the API logs for more details.", a.ID, resp.StatusCode, string(body))
+			}
+			
+			return fmt.Errorf("bad request: %s\n\nStatus: %d\nResponse: %s\n\nTip: Verify that the repository URL is a valid git repository URL (e.g., https://github.com/user/repo.git)", errorMsg, resp.StatusCode, string(body))
 		}
 		if resp.StatusCode == http.StatusConflict {
 			return fmt.Errorf("conflict: An analysis is already running\n\nStatus: %d\nResponse: %s", resp.StatusCode, string(body))
 		}
 		return fmt.Errorf("failed to start analysis: Unexpected response from API\n\nStatus Code: %d\nResponse: %s\n\nTip: Check the huskyCI API status and try again", resp.StatusCode, string(body))
 	}
-	
+
 	// Extract RID from response header
 	RID := resp.Header.Get("X-Request-Id")
 	if RID == "" {
@@ -245,19 +387,19 @@ func (a *Analysis) SendZip() error {
 			}
 		}
 	}
-	
+
 	if RID == "" {
 		return fmt.Errorf("failed to start analysis: No request ID (RID) received from the API\n\nTip: This may indicate an issue with the huskyCI API. Please check the API status")
 	}
-	
+
 	a.RID = RID
 	a.Result.Status = "running"
 	a.StartedAt = time.Now()
-	
+
 	if IsVerbose() {
 		fmt.Printf("[VERBOSE] Analysis started successfully with RID: %s\n", RID)
 	}
-	
+
 	fmt.Println("✓ Code sent successfully!")
 	return nil
 }
@@ -267,7 +409,7 @@ func (a *Analysis) CheckStatus() error {
 	if a.RID == "" {
 		return fmt.Errorf("no RID available - analysis was not started successfully")
 	}
-	
+
 	if a.APITarget == nil {
 		target, err := config.GetCurrentTarget()
 		if err != nil {
@@ -275,48 +417,50 @@ func (a *Analysis) CheckStatus() error {
 		}
 		a.APITarget = target
 	}
-	
+
 	fmt.Println("\n⏳ Checking analysis status...")
-	
+
 	if IsVerbose() {
 		fmt.Printf("[VERBOSE] Analysis RID: %s\n", a.RID)
 		fmt.Printf("[VERBOSE] API endpoint: %s\n", a.APITarget.Endpoint)
 	}
-	
+
 	// Create HTTP client
 	useTLS := util.IsHTTPS(a.APITarget.Endpoint)
 	httpClient, err := util.NewHTTPClient(useTLS)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP client: %w", err)
 	}
-	
+
 	// Poll API for analysis status
 	timeout := time.After(60 * time.Minute)
 	ticker := time.NewTicker(5 * time.Second) // Check every 5 seconds
 	defer ticker.Stop()
-	
+
 	checkCount := 0
-	
+
 	for {
 		select {
 		case <-timeout:
 			return fmt.Errorf("analysis timed out after 60 minutes\n\nTip: Large codebases may take longer to analyze. Try again or contact support if this persists")
 		case <-ticker.C:
 			checkCount++
-			
+
 			// Create GET request
-			apiURL := fmt.Sprintf("%s/analysis/%s", a.APITarget.Endpoint, a.RID)
+			normalizedEndpoint := util.NormalizeURL(a.APITarget.Endpoint)
+			apiURL := fmt.Sprintf("%s/analysis/%s", normalizedEndpoint, a.RID)
 			req, err := http.NewRequest("GET", apiURL, nil)
 			if err != nil {
 				return fmt.Errorf("failed to create HTTP request: %w", err)
 			}
-			
+
 			req.Header.Add("Husky-Token", a.APITarget.Token)
-			
+			req.Header.Add("User-Agent", "huskyci-cli")
+
 			if IsVerbose() && checkCount%12 == 0 { // Log every minute (12 * 5 seconds)
 				fmt.Printf("[VERBOSE] Checking analysis status (attempt #%d)...\n", checkCount)
 			}
-			
+
 			// Send request
 			resp, err := httpClient.Do(req)
 			if err != nil {
@@ -325,10 +469,10 @@ func (a *Analysis) CheckStatus() error {
 				}
 				continue // Retry on network errors
 			}
-			
+
 			body, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			
+
 			if resp.StatusCode == http.StatusNotFound {
 				if checkCount < 3 {
 					// Analysis might not be created yet, wait a bit
@@ -336,18 +480,18 @@ func (a *Analysis) CheckStatus() error {
 				}
 				return fmt.Errorf("analysis not found: No analysis found with RID '%s'\n\nTip: Verify the RID is correct and the analysis exists", a.RID)
 			}
-			
+
 			if resp.StatusCode == http.StatusUnauthorized {
 				return fmt.Errorf("authentication failed: Invalid or expired token\n\nTip: Generate a new token using the huskyCI API")
 			}
-			
+
 			if resp.StatusCode != http.StatusOK {
 				if IsVerbose() {
 					fmt.Printf("[VERBOSE] Unexpected status code %d, will retry\n", resp.StatusCode)
 				}
 				continue // Retry on other errors
 			}
-			
+
 			// Parse response
 			var apiAnalysis types.Analysis
 			if err := json.Unmarshal(body, &apiAnalysis); err != nil {
@@ -356,31 +500,31 @@ func (a *Analysis) CheckStatus() error {
 				}
 				continue
 			}
-			
+
 			// Update analysis status
 			a.Result.Status = apiAnalysis.Status
 			if apiAnalysis.ErrorFound != "" {
 				a.Errors = append(a.Errors, apiAnalysis.ErrorFound)
 			}
-			
+
 			if !apiAnalysis.StartedAt.IsZero() {
 				a.StartedAt = apiAnalysis.StartedAt
 			}
 			if !apiAnalysis.FinishedAt.IsZero() {
 				a.FinishedAt = apiAnalysis.FinishedAt
 			}
-			
+
 			// Convert API vulnerabilities to CLI format
 			if err := a.convertAPIVulnerabilities(apiAnalysis); err != nil {
 				if IsVerbose() {
 					fmt.Printf("[VERBOSE] Warning: Failed to convert vulnerabilities: %v\n", err)
 				}
 			}
-			
+
 			if IsVerbose() {
 				fmt.Printf("[VERBOSE] Current status: %s (check #%d)\n", a.Result.Status, checkCount)
 			}
-			
+
 			// Check if analysis is complete
 			if apiAnalysis.Status == "finished" {
 				if IsVerbose() {
@@ -389,7 +533,7 @@ func (a *Analysis) CheckStatus() error {
 				fmt.Println("✓ Analysis check completed!")
 				return nil
 			}
-			
+
 			if apiAnalysis.Status == "error running" {
 				errorMsg := apiAnalysis.ErrorFound
 				if errorMsg == "" {
@@ -397,7 +541,7 @@ func (a *Analysis) CheckStatus() error {
 				}
 				return fmt.Errorf("analysis failed: %s\n\nTip: Check the analysis details for more information", errorMsg)
 			}
-			
+
 			// Status is "running" or other, continue polling
 		}
 	}
@@ -407,7 +551,7 @@ func (a *Analysis) CheckStatus() error {
 func (a *Analysis) PrintVulns() {
 	fmt.Println("\n📊 Analysis Results:")
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	
+
 	if IsVerbose() {
 		fmt.Printf("[VERBOSE] Analysis ID: %s\n", a.ID)
 		fmt.Printf("[VERBOSE] Status: %s\n", a.Result.Status)
@@ -419,7 +563,7 @@ func (a *Analysis) PrintVulns() {
 			fmt.Printf("[VERBOSE] Errors: %v\n", a.Errors)
 		}
 	}
-	
+
 	// Check if we have any vulnerabilities to display
 	if len(a.Vulnerabilities) == 0 {
 		if a.Result.Status == "" {
@@ -441,13 +585,13 @@ func (a *Analysis) PrintVulns() {
 		}
 		return
 	}
-	
+
 	// Group vulnerabilities by severity
 	highVulns := []vulnerability.Vulnerability{}
 	mediumVulns := []vulnerability.Vulnerability{}
 	lowVulns := []vulnerability.Vulnerability{}
 	infoVulns := []vulnerability.Vulnerability{}
-	
+
 	for _, vuln := range a.Vulnerabilities {
 		switch vuln.Severity {
 		case "HIGH", "high", "High":
@@ -460,7 +604,7 @@ func (a *Analysis) PrintVulns() {
 			infoVulns = append(infoVulns, vuln)
 		}
 	}
-	
+
 	// Print summary
 	fmt.Println("\n📈 Summary:")
 	fmt.Printf("   🔴 High:   %d\n", len(highVulns))
@@ -469,7 +613,7 @@ func (a *Analysis) PrintVulns() {
 	if len(infoVulns) > 0 {
 		fmt.Printf("   ℹ️  Info:   %d\n", len(infoVulns))
 	}
-	
+
 	// Print vulnerabilities by severity
 	if len(highVulns) > 0 {
 		fmt.Println("\n🔴 HIGH SEVERITY VULNERABILITIES:")
@@ -478,7 +622,7 @@ func (a *Analysis) PrintVulns() {
 			printVulnerability(vuln, i+1)
 		}
 	}
-	
+
 	if len(mediumVulns) > 0 {
 		fmt.Println("\n🟠 MEDIUM SEVERITY VULNERABILITIES:")
 		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -486,7 +630,7 @@ func (a *Analysis) PrintVulns() {
 			printVulnerability(vuln, i+1)
 		}
 	}
-	
+
 	if len(lowVulns) > 0 {
 		fmt.Println("\n🟡 LOW SEVERITY VULNERABILITIES:")
 		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -494,7 +638,7 @@ func (a *Analysis) PrintVulns() {
 			printVulnerability(vuln, i+1)
 		}
 	}
-	
+
 	if len(infoVulns) > 0 {
 		fmt.Println("\nℹ️  INFO VULNERABILITIES:")
 		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -507,10 +651,10 @@ func (a *Analysis) PrintVulns() {
 // convertAPIVulnerabilities converts API vulnerability format to CLI format
 func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	a.Vulnerabilities = []vulnerability.Vulnerability{}
-	
+
 	// Convert vulnerabilities from HuskyCIResults
 	results := apiAnalysis.HuskyCIResults
-	
+
 	// Go vulnerabilities (Gosec)
 	for _, vuln := range results.GoResults.HuskyCIGosecOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Go", "gosec"))
@@ -521,7 +665,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.GoResults.HuskyCIGosecOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Go", "gosec"))
 	}
-	
+
 	// Python vulnerabilities (Bandit)
 	for _, vuln := range results.PythonResults.HuskyCIBanditOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Python", "bandit"))
@@ -532,7 +676,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.PythonResults.HuskyCIBanditOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Python", "bandit"))
 	}
-	
+
 	// Python vulnerabilities (Safety)
 	for _, vuln := range results.PythonResults.HuskyCISafetyOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Python", "safety"))
@@ -543,7 +687,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.PythonResults.HuskyCISafetyOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Python", "safety"))
 	}
-	
+
 	// Ruby vulnerabilities (Brakeman)
 	for _, vuln := range results.RubyResults.HuskyCIBrakemanOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Ruby", "brakeman"))
@@ -554,7 +698,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.RubyResults.HuskyCIBrakemanOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Ruby", "brakeman"))
 	}
-	
+
 	// JavaScript vulnerabilities (NpmAudit)
 	for _, vuln := range results.JavaScriptResults.HuskyCINpmAuditOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "JavaScript", "npmaudit"))
@@ -565,7 +709,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "JavaScript", "npmaudit"))
 	}
-	
+
 	// JavaScript vulnerabilities (YarnAudit)
 	for _, vuln := range results.JavaScriptResults.HuskyCIYarnAuditOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "JavaScript", "yarnaudit"))
@@ -576,7 +720,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.JavaScriptResults.HuskyCIYarnAuditOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "JavaScript", "yarnaudit"))
 	}
-	
+
 	// Java vulnerabilities (SpotBugs)
 	for _, vuln := range results.JavaResults.HuskyCISpotBugsOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Java", "spotbugs"))
@@ -587,7 +731,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.JavaResults.HuskyCISpotBugsOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Java", "spotbugs"))
 	}
-	
+
 	// HCL vulnerabilities (TFSec)
 	for _, vuln := range results.HclResults.HuskyCITFSecOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "HCL", "tfsec"))
@@ -598,7 +742,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.HclResults.HuskyCITFSecOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "HCL", "tfsec"))
 	}
-	
+
 	// C# vulnerabilities (SecurityCodeScan)
 	for _, vuln := range results.CSharpResults.HuskyCISecurityCodeScanOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "C#", "securitycodescan"))
@@ -609,7 +753,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.CSharpResults.HuskyCISecurityCodeScanOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "C#", "securitycodescan"))
 	}
-	
+
 	// Generic vulnerabilities (Gitleaks)
 	for _, vuln := range results.GenericResults.HuskyCIGitleaksOutput.HighVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Generic", "gitleaks"))
@@ -620,7 +764,7 @@ func (a *Analysis) convertAPIVulnerabilities(apiAnalysis types.Analysis) error {
 	for _, vuln := range results.GenericResults.HuskyCIGitleaksOutput.LowVulns {
 		a.Vulnerabilities = append(a.Vulnerabilities, convertHuskyCIVulnToCLIVuln(vuln, "Generic", "gitleaks"))
 	}
-	
+
 	return nil
 }
 
@@ -724,6 +868,92 @@ func (a *Analysis) setLanguages(pathReceived string) error {
 		return errors.New("no languages found")
 	}
 	return nil
+}
+
+// generateEnryOutput generates Enry JSON output format (language -> files mapping)
+// This matches the format expected by the API: {"Go": ["file1.go", "file2.go"], "Python": ["file1.py"]}
+func (a *Analysis) generateEnryOutput(pathReceived string) (string, error) {
+	enryMap := make(map[string][]string)
+	
+	err := filepath.Walk(pathReceived,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			// Skip directories
+			if info.IsDir() {
+				return nil
+			}
+			
+			// Get relative path from the root
+			relPath, err := filepath.Rel(pathReceived, path)
+			if err != nil {
+				return err
+			}
+			
+			// Detect language by extension
+			lang, _ := enry.GetLanguageByExtension(info.Name())
+			if lang != "" && lang != "Text" {
+				// Normalize language name to match API expectations (e.g., "Go" not "GoLang")
+				normalizedLang := normalizeLanguageName(lang)
+				if normalizedLang != "" {
+					enryMap[normalizedLang] = append(enryMap[normalizedLang], relPath)
+				}
+			}
+			return nil
+		})
+	
+	if err != nil {
+		return "", fmt.Errorf("error generating Enry output: %w", err)
+	}
+	
+	// Convert to JSON
+	enryJSON, err := json.Marshal(enryMap)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling Enry output: %w", err)
+	}
+	
+	return string(enryJSON), nil
+}
+
+// normalizeLanguageName normalizes language names to match API expectations
+func normalizeLanguageName(lang string) string {
+	// Map common language variations to API-expected names
+	normalizations := map[string]string{
+		"Go":        "Go",
+		"Golang":    "Go",
+		"Python":    "Python",
+		"Ruby":      "Ruby",
+		"JavaScript": "JavaScript",
+		"TypeScript": "JavaScript", // TypeScript files are often analyzed with JS tools
+		"Java":      "Java",
+		"C#":        "C#",
+		"CSharp":    "C#",
+		"HCL":       "HCL",
+		"Terraform": "HCL",
+	}
+	
+	if normalized, ok := normalizations[lang]; ok {
+		return normalized
+	}
+	
+	// Return empty string for unsupported languages
+	// Only return languages that HuskyCI supports
+	supportedLanguages := map[string]bool{
+		"Go":         true,
+		"Python":     true,
+		"Ruby":       true,
+		"JavaScript": true,
+		"Java":       true,
+		"C#":         true,
+		"HCL":        true,
+	}
+	
+	if supportedLanguages[lang] {
+		return lang
+	}
+	
+	return ""
 }
 
 // getAvailableSecurityTests returns the huskyCI securityTests available.

--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -1,0 +1,939 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/huskyci-org/huskyCI/cli/config"
+	"github.com/huskyci-org/huskyCI/cli/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	separatorLine = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+)
+
+// setupCmd represents the setup command
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Interactive setup wizard for huskyCI CLI",
+	Long: `Interactive setup wizard that guides you through configuring huskyCI CLI.
+
+This command will help you:
+  1. Configure your huskyCI API endpoint
+  2. Set up authentication (optional)
+  3. Verify your connection
+  4. Set up your first target
+
+Examples:
+  # Start the setup wizard
+  huskyci setup
+
+  # Run setup with non-interactive mode (for automation)
+  huskyci setup --non-interactive`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
+		wizard := newSetupWizard(nonInteractive)
+		return wizard.run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+	setupCmd.Flags().Bool("non-interactive", false, "Run setup in non-interactive mode (for automation)")
+}
+
+// setupWizard manages the entire setup flow
+type setupWizard struct {
+	nonInteractive bool
+	scanner        *bufio.Scanner
+	existingTargets map[string]interface{}
+}
+
+func newSetupWizard(nonInteractive bool) *setupWizard {
+	return &setupWizard{
+		nonInteractive:  nonInteractive,
+		scanner:         bufio.NewScanner(os.Stdin),
+		existingTargets: viper.GetStringMap("targets"),
+	}
+}
+
+// run executes the main setup wizard flow
+func (w *setupWizard) run() error {
+	w.printWelcome()
+
+	// Handle existing targets if any
+	if len(w.existingTargets) > 0 {
+		if !w.handleExistingTargets() {
+			return nil // User chose to exit
+		}
+	}
+
+	// Main setup flow: endpoint -> target name -> token -> save -> verify
+	endpoint, err := w.collectEndpoint()
+	if err != nil {
+		return err
+	}
+
+	targetName, err := w.collectTargetName()
+	if err != nil {
+		return err
+	}
+
+	token, useToken := w.collectToken()
+
+	if err := w.saveTarget(targetName, endpoint); err != nil {
+		return err
+	}
+
+	// If user provided a token, set it up
+	if useToken && token != "" {
+		w.setupToken(token)
+	}
+
+	w.verifyConnection(endpoint, token, useToken)
+	w.printSummary(endpoint, useToken)
+
+	return nil
+}
+
+// ============================================================================
+// UI Components
+// ============================================================================
+
+func (w *setupWizard) printWelcome() {
+	fmt.Println()
+	fmt.Println(separatorLine)
+	fmt.Println("  🐕  Welcome to huskyCI Setup Wizard!")
+	fmt.Println(separatorLine)
+	fmt.Println()
+	fmt.Println("This wizard will help you configure huskyCI CLI to work with your huskyCI API.")
+	fmt.Println()
+}
+
+func (w *setupWizard) printSection(title string) {
+	fmt.Println()
+	fmt.Println(title)
+	fmt.Println(strings.Repeat("─", len(title)))
+	fmt.Println()
+}
+
+func (w *setupWizard) printSuccess(message string) {
+	fmt.Printf("✓ %s\n", message)
+}
+
+func (w *setupWizard) printWarning(message string) {
+	fmt.Printf("⚠️  %s\n", message)
+}
+
+func (w *setupWizard) printError(message string) {
+	fmt.Printf("✗ %s\n", message)
+}
+
+// ============================================================================
+// Menu System
+// ============================================================================
+
+type menuOption struct {
+	key         string
+	description string
+	handler     func() menuResult
+}
+
+type menuResult int
+
+const (
+	menuContinue menuResult = iota
+	menuReturn
+	menuExit
+)
+
+func (w *setupWizard) showMenu(title string, options []menuOption) menuResult {
+	for {
+		fmt.Println()
+		if title != "" {
+			fmt.Println(title)
+		}
+		for _, opt := range options {
+			fmt.Printf("  %s. %s\n", opt.key, opt.description)
+		}
+		fmt.Println()
+		fmt.Print("Enter your choice: ")
+
+		if !w.scanner.Scan() {
+			return menuExit
+		}
+
+		choice := strings.TrimSpace(w.scanner.Text())
+		fmt.Println()
+
+		for _, opt := range options {
+			if opt.key == choice {
+				return opt.handler()
+			}
+		}
+
+		w.printWarning("Invalid choice. Please try again.")
+	}
+}
+
+// ============================================================================
+// Existing Targets Handling
+// ============================================================================
+
+func (w *setupWizard) handleExistingTargets() bool {
+	if w.nonInteractive {
+		return true
+	}
+
+	w.printSection("Existing Configuration")
+	fmt.Println("You already have some targets configured:")
+	fmt.Println()
+
+	for name, v := range w.existingTargets {
+		target := v.(map[string]interface{})
+		current := ""
+		if target["current"] != nil && target["current"].(bool) {
+			current = " (current)"
+		}
+		fmt.Printf("  • %s: %s%s\n", name, target["endpoint"], current)
+	}
+	fmt.Println()
+
+	result := w.showMenu("What would you like to do?", []menuOption{
+		{"1", "Add a new target", func() menuResult {
+			return menuContinue
+		}},
+		{"2", "Test connection to current target", func() menuResult {
+			return w.handleTestConnection()
+		}},
+		{"3", "Configure authentication token", func() menuResult {
+			return w.handleConfigureToken()
+		}},
+		{"4", "View current configuration", func() menuResult {
+			return w.handleViewConfiguration()
+		}},
+		{"5", "Exit", func() menuResult {
+			w.printSuccess("Exiting setup wizard.")
+			fmt.Println("  Any changes made during this session have been applied.")
+			return menuExit
+		}},
+	})
+
+	return result == menuContinue
+}
+
+func (w *setupWizard) handleTestConnection() menuResult {
+	if _, err := config.GetCurrentTarget(); err != nil {
+		w.printError(fmt.Sprintf("Error getting current target: %v", err))
+		fmt.Println()
+		return w.askNextAction()
+	}
+
+	fmt.Println("Running connection test...")
+	fmt.Println()
+
+	if err := runConnectionTest("", "", false); err != nil {
+		fmt.Println()
+		return w.askNextAction()
+	}
+
+	fmt.Println()
+	return w.askNextAction()
+}
+
+func (w *setupWizard) handleConfigureToken() menuResult {
+	w.printSection("Token Configuration")
+	fmt.Println("How would you like to configure your authentication token?")
+	fmt.Println()
+
+	result := w.showMenu("", []menuOption{
+		{"1", "Enter token manually", func() menuResult {
+			return w.handleManualToken()
+		}},
+		{"2", "Generate token via API", func() menuResult {
+			return w.handleGenerateToken()
+		}},
+	})
+
+	if result == menuExit {
+		return menuExit
+	}
+	return w.askNextAction()
+}
+
+func (w *setupWizard) handleManualToken() menuResult {
+	w.printSection("Manual Token Configuration")
+	fmt.Print("Enter your huskyCI API token: ")
+
+	if !w.scanner.Scan() {
+		return menuExit
+	}
+
+	token := strings.TrimSpace(w.scanner.Text())
+	if token == "" {
+		w.printWarning("No token provided. Token configuration cancelled.")
+		fmt.Println()
+		return menuReturn
+	}
+
+	w.setupToken(token)
+	return menuContinue
+}
+
+func (w *setupWizard) handleGenerateToken() menuResult {
+	w.printSection("Generate Token via API")
+
+	target, err := config.GetCurrentTarget()
+	if err != nil {
+		w.printError(fmt.Sprintf("Error getting current target: %v", err))
+		fmt.Println("  Please configure a target first using option 1.")
+		fmt.Println()
+		return menuReturn
+	}
+
+	endpoint := normalizeURL(target.Endpoint)
+	token, err := w.generateTokenFromAPI(endpoint)
+	if err != nil {
+		w.printError(err.Error())
+		fmt.Println()
+		return menuReturn
+	}
+
+	w.setupToken(token)
+	return menuContinue
+}
+
+func (w *setupWizard) handleViewConfiguration() menuResult {
+	w.printSection("Current Configuration")
+
+	target, err := config.GetCurrentTarget()
+	if err == nil {
+		fmt.Printf("Current Target: %s\n", target.Label)
+		fmt.Printf("Endpoint: %s\n", target.Endpoint)
+		if target.Token != "" {
+			fmt.Printf("Token: %s... (configured)\n", target.Token[:min(10, len(target.Token))])
+		} else {
+			fmt.Println("Token: Not configured")
+		}
+		fmt.Println()
+	}
+
+	fmt.Println("All Targets:")
+	for name, v := range w.existingTargets {
+		target := v.(map[string]interface{})
+		current := ""
+		if target["current"] != nil && target["current"].(bool) {
+			current = " (current)"
+		}
+		fmt.Printf("  • %s: %s%s\n", name, target["endpoint"], current)
+	}
+	fmt.Println()
+
+	if os.Getenv("HUSKYCI_CLIENT_API_ADDR") != "" {
+		fmt.Println("Environment Variables:")
+		fmt.Printf("  HUSKYCI_CLIENT_API_ADDR: %s\n", os.Getenv("HUSKYCI_CLIENT_API_ADDR"))
+		token := config.GetTokenFromEnv()
+		if token != "" {
+			fmt.Printf("  HUSKYCI_CLI_TOKEN: %s... (configured)\n", token[:min(10, len(token))])
+		}
+		fmt.Println()
+	}
+
+	return w.askNextAction()
+}
+
+func (w *setupWizard) askNextAction() menuResult {
+	return w.showMenu("What would you like to do next?", []menuOption{
+		{"1", "Return to main menu", func() menuResult {
+			return menuReturn
+		}},
+		{"2", "Add a new target", func() menuResult {
+			return menuContinue
+		}},
+		{"3", "Exit", func() menuResult {
+			w.printSuccess("Exiting setup wizard.")
+			fmt.Println("  Any changes made during this session have been applied.")
+			return menuExit
+		}},
+	})
+}
+
+// ============================================================================
+// Data Collection
+// ============================================================================
+
+func (w *setupWizard) collectEndpoint() (string, error) {
+	if w.nonInteractive {
+		endpoint := os.Getenv("HUSKYCI_CLIENT_API_ADDR")
+		if endpoint == "" {
+			endpoint = "http://localhost:8888"
+			fmt.Printf("Using default endpoint: %s\n", endpoint)
+		}
+		return endpoint, nil
+	}
+
+	w.printSection("Step 1: Configure API Endpoint")
+	fmt.Print("Enter your huskyCI API endpoint URL (e.g., https://api.huskyci.example.com or http://localhost:8888): ")
+
+	if !w.scanner.Scan() {
+		return "", fmt.Errorf("failed to read input")
+	}
+
+	endpoint := strings.TrimSpace(w.scanner.Text())
+	if err := validateEndpoint(endpoint); err != nil {
+		return "", err
+	}
+
+	return endpoint, nil
+}
+
+func (w *setupWizard) collectTargetName() (string, error) {
+	if w.nonInteractive {
+		targetName := "default"
+		if len(w.existingTargets) > 0 {
+			targetName = fmt.Sprintf("target-%d", len(w.existingTargets)+1)
+		}
+		fmt.Printf("Using target name: %s\n", targetName)
+		return targetName, nil
+	}
+
+	w.printSection("Step 2: Configure Target Name")
+	fmt.Print("Enter a name for this target (letters, numbers, underscores only, e.g., 'production', 'staging'): ")
+
+	if !w.scanner.Scan() {
+		return "", fmt.Errorf("failed to read input")
+	}
+
+	targetName := strings.TrimSpace(w.scanner.Text())
+	if err := validateTargetName(targetName, w.existingTargets); err != nil {
+		return "", err
+	}
+
+	return targetName, nil
+}
+
+func (w *setupWizard) collectToken() (string, bool) {
+	if w.nonInteractive {
+		token := config.GetTokenFromEnv()
+		return token, token != ""
+	}
+
+	fmt.Println()
+	fmt.Print("Do you want to configure an authentication token now? (y/n): ")
+
+	if !w.scanner.Scan() {
+		return "", false
+	}
+
+	response := strings.ToLower(strings.TrimSpace(w.scanner.Text()))
+	if response != "y" && response != "yes" {
+		return "", false
+	}
+
+	fmt.Print("Enter your huskyCI API token: ")
+
+	if !w.scanner.Scan() {
+		return "", false
+	}
+
+	token := strings.TrimSpace(w.scanner.Text())
+	if token == "" {
+		w.printWarning("No token provided. You can set it later using:")
+		fmt.Println("   export HUSKYCI_CLI_TOKEN=\"your-token\"")
+		return "", false
+	}
+
+	return token, true
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+func validateEndpoint(endpoint string) error {
+	if endpoint == "" {
+		return fmt.Errorf("endpoint URL cannot be empty")
+	}
+
+	parsedURL, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %w\n\nPlease enter a valid URL (e.g., https://api.huskyci.example.com)", err)
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return fmt.Errorf("URL must include scheme (http:// or https://) and host\n\nExample: https://api.huskyci.example.com")
+	}
+
+	return nil
+}
+
+func validateTargetName(targetName string, existingTargets map[string]interface{}) error {
+	if targetName == "" {
+		return fmt.Errorf("target name cannot be empty")
+	}
+
+	match, err := regexp.MatchString(`^\w+$`, targetName)
+	if err != nil {
+		return fmt.Errorf("error validating target name: %w", err)
+	}
+	if !match {
+		return fmt.Errorf("invalid target name '%s': target name must contain only letters, numbers, and underscores\n\nExample: production, staging, local", targetName)
+	}
+
+	for k := range existingTargets {
+		if k == targetName {
+			return fmt.Errorf("target name '%s' already exists\n\nTip: Use 'huskyci target-remove %s' to remove it first, or choose a different name", targetName, targetName)
+		}
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Configuration Management
+// ============================================================================
+
+func (w *setupWizard) saveTarget(targetName, endpoint string) error {
+	targets := viper.GetStringMap("targets")
+	
+	// Mark all existing targets as not current
+	for _, v := range targets {
+		target := v.(map[string]interface{})
+		target["current"] = false
+	}
+
+	// Add new target as current
+	targets[targetName] = map[string]interface{}{
+		"current":       true,
+		"endpoint":      endpoint,
+		"token-storage": "file",
+	}
+
+	viper.Set("targets", targets)
+	if err := viper.WriteConfig(); err != nil {
+		return fmt.Errorf("error saving configuration: %w\n\nTip: Check if you have write permissions to the config file", err)
+	}
+
+	fmt.Println()
+	w.printSuccess(fmt.Sprintf("Successfully added target '%s' -> %s", targetName, endpoint))
+	w.printSuccess(fmt.Sprintf("Set '%s' as the current target", targetName))
+	
+	return nil
+}
+
+// ============================================================================
+// Token Management
+// ============================================================================
+
+func (w *setupWizard) setupToken(token string) {
+	fmt.Println()
+	fmt.Println("How would you like to set the token?")
+	fmt.Println()
+
+	result := w.showMenu("", []menuOption{
+		{"1", "Show command to set for current session", func() menuResult {
+			w.showTokenCommand(token, false)
+			return menuContinue
+		}},
+		{"2", "Add to shell profile (detected automatically)", func() menuResult {
+			w.addTokenToProfile(token)
+			return menuContinue
+		}},
+		{"3", "Just show the command (I'll set it myself)", func() menuResult {
+			w.showTokenCommand(token, true)
+			return menuContinue
+		}},
+	})
+
+	if result == menuExit {
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("After setting up your token, you can test the connection using:")
+	fmt.Println("  huskyci test-connection")
+	fmt.Println()
+}
+
+func (w *setupWizard) showTokenCommand(token string, manual bool) {
+	_, profileFile, _ := getDetectedShell()
+	exportCmd := getShellExportCommand(token, profileFile)
+
+	if manual {
+		fmt.Println("To set the token manually, run:")
+		fmt.Printf("  %s\n", exportCmd)
+	} else {
+		fmt.Println("To set the token for your current shell session, run:")
+		fmt.Printf("  %s\n", exportCmd)
+		fmt.Println()
+		fmt.Println("  Note: This will only last for this terminal session")
+		fmt.Println("  To make it permanent, choose option 2 to add it to your shell profile")
+	}
+}
+
+func (w *setupWizard) addTokenToProfile(token string) {
+	if err := addTokenToShellProfile(token); err != nil {
+		w.printError(fmt.Sprintf("Error adding to shell profile: %v", err))
+		_, profileFile, _ := getDetectedShell()
+		exportCmd := getShellExportCommand(token, profileFile)
+		fmt.Println("  You can manually add this line to your shell profile:")
+		fmt.Printf("  %s\n", exportCmd)
+		fmt.Printf("  (Add to: %s)\n", profileFile)
+	} else {
+		_, profileFile, _ := getDetectedShell()
+		w.printSuccess("Token added to shell profile")
+		fmt.Printf("  Please restart your terminal or run: source %s\n", profileFile)
+	}
+}
+
+func (w *setupWizard) generateTokenFromAPI(endpoint string) (string, error) {
+	fmt.Println("Please provide the following information:")
+	fmt.Println()
+
+	// Get username
+	fmt.Print("API Username: ")
+	if !w.scanner.Scan() {
+		return "", fmt.Errorf("failed to read username")
+	}
+	username := strings.TrimSpace(w.scanner.Text())
+	if username == "" {
+		return "", fmt.Errorf("username cannot be empty")
+	}
+
+	// Get password
+	fmt.Print("API Password: ")
+	if !w.scanner.Scan() {
+		return "", fmt.Errorf("failed to read password")
+	}
+	password := strings.TrimSpace(w.scanner.Text())
+	if password == "" {
+		return "", fmt.Errorf("password cannot be empty")
+	}
+
+	// Get repository URL (optional - empty for generic token)
+	fmt.Print("Repository URL (e.g., https://github.com/user/repo.git) or press Enter for generic token: ")
+	if !w.scanner.Scan() {
+		return "", fmt.Errorf("failed to read repository URL")
+	}
+	repoURL := strings.TrimSpace(w.scanner.Text())
+	// Empty URL is now valid - it creates a generic token
+
+	fmt.Println()
+	fmt.Println("Generating token...")
+
+	tokenURL := endpoint + "/api/1.0/token"
+	payload := map[string]string{
+		"repositoryURL": repoURL,
+	}
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("error creating request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", tokenURL, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return "", fmt.Errorf("error creating request: %w", err)
+	}
+
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	req.Header.Set("Authorization", "Basic "+auth)
+	req.Header.Set("Content-Type", "application/json")
+
+	useHTTPS := util.IsHTTPS(endpoint)
+	client, err := util.NewHTTPClient(useHTTPS)
+	if err != nil {
+		return "", fmt.Errorf("error creating HTTP client: %w", err)
+	}
+	client.Timeout = 30 * time.Second
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error connecting to API: %w\n\nPlease verify:\n  - The API endpoint is correct\n  - The API server is running\n  - Your network connection is working", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		// Try to parse error response for better error message
+		var errorResponse map[string]interface{}
+		if err := json.Unmarshal(body, &errorResponse); err == nil {
+			if errorMsg, ok := errorResponse["error"].(string); ok {
+				return "", fmt.Errorf("token generation failed (status %d)\n  Error: %s\n\nPlease verify:\n  - Your API credentials are correct\n  - The repository URL is valid\n  - The API server is functioning properly", resp.StatusCode, errorMsg)
+			}
+		}
+		return "", fmt.Errorf("token generation failed (status %d)\n  Response: %s\n\nPlease verify:\n  - Your API credentials are correct\n  - The repository URL is valid\n  - The API server is functioning properly", resp.StatusCode, string(body))
+	}
+
+	var token string
+	var responseBody map[string]interface{}
+	if err := json.Unmarshal(body, &responseBody); err == nil {
+		if t, ok := responseBody["huskytoken"].(string); ok {
+			token = t
+		} else if t, ok := responseBody["token"].(string); ok {
+			token = t
+		}
+	}
+
+	if token == "" {
+		token = strings.TrimSpace(string(body))
+		token = strings.Trim(token, "\"'")
+	}
+
+	if token == "" {
+		return "", fmt.Errorf("token generation succeeded but no token found in response\n  Response: %s", string(body))
+	}
+
+	w.printSuccess("Token generated successfully!")
+	return token, nil
+}
+
+// ============================================================================
+// Connection Verification
+// ============================================================================
+
+func (w *setupWizard) verifyConnection(endpoint, token string, useToken bool) {
+	if w.nonInteractive {
+		if useToken {
+			if err := verifyConnection(endpoint, token); err != nil {
+				w.printWarning(fmt.Sprintf("Connection verification failed: %v", err))
+			} else {
+				w.printSuccess("Connection verified successfully!")
+			}
+		}
+		return
+	}
+
+	fmt.Println()
+	fmt.Print("Do you want to verify the connection to the API? (y/n): ")
+
+	if !w.scanner.Scan() {
+		return
+	}
+
+	response := strings.ToLower(strings.TrimSpace(w.scanner.Text()))
+	if response != "y" && response != "yes" {
+		return
+	}
+
+	if err := verifyConnection(endpoint, token); err != nil {
+		w.printWarning(fmt.Sprintf("Connection verification failed: %v", err))
+		fmt.Println("   You can still use huskyCI CLI, but please verify your endpoint and token.")
+	} else {
+		w.printSuccess("Connection verified successfully!")
+	}
+}
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+func (w *setupWizard) printSummary(endpoint string, useToken bool) {
+	fmt.Println()
+	fmt.Println(separatorLine)
+	fmt.Println("  ✓ Setup Complete!")
+	fmt.Println(separatorLine)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println()
+
+	if !useToken {
+		fmt.Println("  1. Set your authentication token:")
+		fmt.Println("     export HUSKYCI_CLI_TOKEN=\"your-token\"")
+		fmt.Println()
+		fmt.Println("     Or generate a token via the API:")
+		fmt.Printf("     curl -X POST %s/api/1.0/token \\\n", endpoint)
+		fmt.Println("       -u username:password \\")
+		fmt.Println("       -H \"Content-Type: application/json\" \\")
+		fmt.Println("       -d '{\"repositoryURL\": \"https://github.com/user/repo.git\"}'")
+		fmt.Println()
+	}
+
+	fmt.Println("  2. Run your first security analysis:")
+	fmt.Println("     huskyci run ./my-project")
+	fmt.Println()
+	fmt.Println("  3. List all configured targets:")
+	fmt.Println("     huskyci target-list")
+	fmt.Println()
+	fmt.Println("For more information, visit: https://github.com/huskyci-org/huskyCI")
+	fmt.Println()
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+func verifyConnection(endpoint string, token string) error {
+	client, err := createHTTPClient(endpoint)
+	if err != nil {
+		return err
+	}
+
+	baseURL := normalizeURL(endpoint)
+	if err := tryConnection(client, baseURL, token, endpoint); err == nil {
+		return nil
+	}
+
+	rootURL := baseURL + "/"
+	return tryConnection(client, rootURL, token, endpoint)
+}
+
+func createHTTPClient(endpoint string) (*http.Client, error) {
+	useHTTPS := util.IsHTTPS(endpoint)
+	client, err := util.NewHTTPClient(useHTTPS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	client.Timeout = 10 * time.Second
+	return client, nil
+}
+
+func normalizeURL(url string) string {
+	if strings.HasSuffix(url, "/") {
+		return url[:len(url)-1]
+	}
+	return url
+}
+
+func tryConnection(client *http.Client, url, token, endpoint string) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if token != "" {
+		req.Header.Set("Husky-Token", token)
+	}
+	req.Header.Set("User-Agent", "huskyci-cli")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to connect to %s: %w\n\nPlease verify:\n  - The API endpoint is correct\n  - The API server is running\n  - Your network connection is working", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return fmt.Errorf("endpoint is reachable but authentication failed (status %d)\n\nTip: Verify your token is correct. You can still use huskyCI CLI, but authentication may be required for actual operations", resp.StatusCode)
+		}
+		return nil
+	}
+
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("endpoint is reachable but server returned error (status %d)\n\nTip: The API server may be experiencing issues. You can still use huskyCI CLI, but operations may fail", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func getDetectedShell() (shellName string, profileFile string, err error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", err
+	}
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/bash"
+	}
+
+	shell = strings.ToLower(shell)
+	shellBase := filepath.Base(shell)
+
+	switch {
+	case strings.Contains(shellBase, "fish"):
+		configDir := home + "/.config/fish"
+		profileFile = configDir + "/config.fish"
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			return "", "", fmt.Errorf("failed to create fish config directory: %w", err)
+		}
+		return "fish", profileFile, nil
+	case strings.Contains(shellBase, "zsh"):
+		profileFile = home + "/.zshrc"
+		return "zsh", profileFile, nil
+	case strings.Contains(shellBase, "bash"):
+		profileFile = home + "/.bashrc"
+		if _, err := os.Stat(profileFile); os.IsNotExist(err) {
+			profileFile = home + "/.bash_profile"
+		}
+		return "bash", profileFile, nil
+	case strings.Contains(shellBase, "csh") || strings.Contains(shellBase, "tcsh"):
+		profileFile = home + "/.cshrc"
+		if _, err := os.Stat(profileFile); os.IsNotExist(err) {
+			profileFile = home + "/.tcshrc"
+		}
+		return "csh", profileFile, nil
+	default:
+		profileFile = home + "/.bashrc"
+		if _, err := os.Stat(profileFile); os.IsNotExist(err) {
+			profileFile = home + "/.bash_profile"
+		}
+		return "bash", profileFile, nil
+	}
+}
+
+func getShellExportCommand(token string, profileFile string) string {
+	if strings.Contains(profileFile, "fish") {
+		return fmt.Sprintf("set -x HUSKYCI_CLI_TOKEN \"%s\"", token)
+	}
+	return fmt.Sprintf("export HUSKYCI_CLI_TOKEN=\"%s\"", token)
+}
+
+func addTokenToShellProfile(token string) error {
+	_, profileFile, err := getDetectedShell()
+	if err != nil {
+		return err
+	}
+
+	content, err := os.ReadFile(profileFile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	exportLine := getShellExportCommand(token, profileFile)
+	hasCLIToken := strings.Contains(string(content), "HUSKYCI_CLI_TOKEN")
+
+	if hasCLIToken {
+		lines := strings.Split(string(content), "\n")
+		var newLines []string
+		replaced := false
+		for _, line := range lines {
+			if strings.Contains(line, "HUSKYCI_CLI_TOKEN") {
+				if !replaced {
+					newLines = append(newLines, exportLine)
+					replaced = true
+				}
+			} else {
+				newLines = append(newLines, line)
+			}
+		}
+		content = []byte(strings.Join(newLines, "\n"))
+	} else {
+		if len(content) > 0 && !strings.HasSuffix(string(content), "\n") {
+			content = append(content, '\n')
+		}
+		content = append(content, []byte(fmt.Sprintf("\n# huskyCI CLI Token\n%s\n", exportLine))...)
+	}
+
+	return os.WriteFile(profileFile, content, 0644)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cli/cmd/testConnection.go
+++ b/cli/cmd/testConnection.go
@@ -1,0 +1,554 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/huskyci-org/huskyCI/cli/config"
+	"github.com/huskyci-org/huskyCI/cli/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// testConnectionCmd represents the test-connection command
+var testConnectionCmd = &cobra.Command{
+	Use:   "test-connection [target-name]",
+	Short: "Test connection to huskyCI API server",
+	Long: `Test connectivity and verify configuration for huskyCI API server.
+
+This command performs several connection tests:
+  1. Basic connectivity to the API endpoint
+  2. Health check endpoint (/healthcheck)
+  3. Version endpoint (/version)
+  4. Authentication (if token is configured)
+
+You can test:
+  - Current target (default)
+  - Specific target by name
+  - Custom endpoint via --endpoint flag
+
+Examples:
+  # Test current target
+  huskyci test-connection
+
+  # Test specific target
+  huskyci test-connection production
+
+  # Test custom endpoint
+  huskyci test-connection --endpoint https://api.huskyci.example.com
+
+  # Test with verbose output
+  huskyci test-connection --verbose`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		endpoint, _ := cmd.Flags().GetString("endpoint")
+		skipAuth, _ := cmd.Flags().GetBool("skip-auth")
+		
+		var targetName string
+		if len(args) > 0 {
+			targetName = args[0]
+		}
+
+		return runConnectionTest(endpoint, targetName, skipAuth)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(testConnectionCmd)
+	testConnectionCmd.Flags().String("endpoint", "", "Test a specific endpoint URL (overrides target selection)")
+	testConnectionCmd.Flags().Bool("skip-auth", false, "Skip authentication tests")
+}
+
+// ConnectionTestResult holds the results of connection tests
+type ConnectionTestResult struct {
+	TestName      string
+	Success       bool
+	Status        string
+	StatusCode    int
+	ResponseTime  time.Duration
+	ErrorMessage  string
+	ResponseBody  string
+}
+
+// runConnectionTest executes connection tests
+func runConnectionTest(customEndpoint, targetName string, skipAuth bool) error {
+	var endpoint string
+	var token string
+	var label string
+
+	fmt.Println()
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("  🔌 huskyCI API Connection Test")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println()
+
+	// Determine endpoint and token
+	if customEndpoint != "" {
+		endpoint = customEndpoint
+		label = "custom endpoint"
+		token = config.GetTokenFromEnv() // Check environment variable for token
+		if IsVerbose() {
+			fmt.Printf("[VERBOSE] Using custom endpoint: %s\n", endpoint)
+		}
+	} else {
+		target, err := getTargetForTest(targetName)
+		if err != nil {
+			return err
+		}
+		endpoint = target.Endpoint
+		token = target.Token
+		label = target.Label
+		fmt.Printf("Testing target: %s\n", label)
+		fmt.Printf("Endpoint: %s\n", endpoint)
+		fmt.Println()
+	}
+
+	// Run tests
+	results := []ConnectionTestResult{}
+
+	// Test 1: Basic connectivity
+	fmt.Println("Test 1: Basic Connectivity")
+	fmt.Println("──────────────────────────────────────────────────────────────────────────────")
+	result := testBasicConnectivity(endpoint)
+	results = append(results, result)
+	printTestResult(result)
+	fmt.Println()
+
+	if !result.Success {
+		fmt.Println("⚠️  Basic connectivity failed. Skipping remaining tests.")
+		printTestSummary(results)
+		return fmt.Errorf("connection test failed: %s", result.ErrorMessage)
+	}
+
+	// Test 2: Health check
+	fmt.Println("Test 2: Health Check Endpoint")
+	fmt.Println("──────────────────────────────────────────────────────────────────────────────")
+	result = testHealthCheck(endpoint)
+	results = append(results, result)
+	printTestResult(result)
+	fmt.Println()
+
+	// Test 3: Version endpoint
+	fmt.Println("Test 3: Version Endpoint")
+	fmt.Println("──────────────────────────────────────────────────────────────────────────────")
+	result = testVersionEndpoint(endpoint)
+	results = append(results, result)
+	printTestResult(result)
+	fmt.Println()
+
+	// Test 4: Authentication (if token available and not skipped)
+	if !skipAuth && token != "" {
+		fmt.Println("Test 4: Authentication")
+		fmt.Println("──────────────────────────────────────────────────────────────────────────────")
+		result = testAuthentication(endpoint, token)
+		results = append(results, result)
+		printTestResult(result)
+		fmt.Println()
+	} else if !skipAuth && token == "" {
+		fmt.Println("Test 4: Authentication")
+		fmt.Println("──────────────────────────────────────────────────────────────────────────────")
+		fmt.Println("⚠️  Skipped: No authentication token configured")
+		fmt.Println("   Tip: Set HUSKYCI_CLI_TOKEN or configure token storage")
+		fmt.Println()
+	}
+
+	// Print summary
+	printTestSummary(results)
+
+	// Return error if any critical test failed
+	for _, r := range results {
+		if !r.Success && r.TestName != "Authentication" {
+			return fmt.Errorf("connection test failed: %s", r.ErrorMessage)
+		}
+	}
+
+	return nil
+}
+
+// getTargetForTest retrieves the target to test
+func getTargetForTest(targetName string) (*types.Target, error) {
+	if targetName != "" {
+		// Get specific target from config
+		targets := viper.GetStringMap("targets")
+		if target, exists := targets[targetName]; exists {
+			targetMap := target.(map[string]interface{})
+			// Get token from environment if available
+			token := config.GetTokenFromEnv()
+			return &types.Target{
+				Label:    targetName,
+				Endpoint: targetMap["endpoint"].(string),
+				Token:    token,
+			}, nil
+		}
+		return nil, fmt.Errorf("target '%s' not found\n\nTip: Use 'huskyci target-list' to see available targets", targetName)
+	}
+
+	// Get current target
+	target, err := config.GetCurrentTarget()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get target: %w\n\nTip: Configure a target using 'huskyci target-add <name> <endpoint>' or 'huskyci setup'", err)
+	}
+
+	return target, nil
+}
+
+// testBasicConnectivity tests basic connectivity to the endpoint
+// A 404 or other 4xx response indicates the server is reachable (just the path doesn't exist)
+// Only 5xx errors or connection failures indicate actual connectivity issues
+func testBasicConnectivity(endpoint string) ConnectionTestResult {
+	start := time.Now()
+	result := ConnectionTestResult{
+		TestName: "Basic Connectivity",
+	}
+
+	client, err := createHTTPClient(endpoint)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create HTTP client: %v", err)
+		return result
+	}
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create request: %v", err)
+		return result
+	}
+
+	resp, err := client.Do(req)
+	result.ResponseTime = time.Since(start)
+
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Connection failed: %v", err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	result.StatusCode = resp.StatusCode
+	result.Status = resp.Status
+
+	// Any HTTP response (including 404) means the server is reachable
+	// 2xx/3xx = success, 4xx = endpoint exists but path not found (still success for connectivity)
+	// 5xx = server error (still reachable, but server has issues)
+	if resp.StatusCode < 500 {
+		result.Success = true
+		if resp.StatusCode == http.StatusNotFound {
+			result.Status = "Endpoint is reachable (404 - path not found, but server is responding)"
+		} else if resp.StatusCode < 400 {
+			result.Status = "Endpoint is reachable"
+		} else {
+			result.Status = fmt.Sprintf("Endpoint is reachable (status %d)", resp.StatusCode)
+		}
+	} else {
+		// 5xx errors indicate server issues, but connectivity is still successful
+		result.Success = true
+		result.Status = fmt.Sprintf("Endpoint is reachable but server returned error (status %d)", resp.StatusCode)
+		result.ErrorMessage = fmt.Sprintf("Server error: status %d", resp.StatusCode)
+	}
+
+	return result
+}
+
+// testHealthCheck tests the /healthcheck endpoint
+func testHealthCheck(endpoint string) ConnectionTestResult {
+	start := time.Now()
+	result := ConnectionTestResult{
+		TestName: "Health Check",
+	}
+
+	client, err := createHTTPClient(endpoint)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create HTTP client: %v", err)
+		return result
+	}
+
+	healthURL := normalizeURL(endpoint) + "/healthcheck"
+	req, err := http.NewRequest("GET", healthURL, nil)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create request: %v", err)
+		return result
+	}
+
+	resp, err := client.Do(req)
+	result.ResponseTime = time.Since(start)
+
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Request failed: %v", err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := strings.TrimSpace(string(body))
+	result.StatusCode = resp.StatusCode
+	result.Status = resp.Status
+	result.ResponseBody = bodyStr
+
+	if resp.StatusCode == http.StatusOK && bodyStr == "WORKING" {
+		result.Success = true
+		result.Status = "Health check passed"
+	} else if resp.StatusCode == http.StatusOK {
+		result.Success = true
+		result.Status = fmt.Sprintf("Health check responded (unexpected body: %s)", bodyStr)
+	} else {
+		result.ErrorMessage = fmt.Sprintf("Health check failed: status %d, body: %s", resp.StatusCode, bodyStr)
+	}
+
+	return result
+}
+
+// testVersionEndpoint tests the /version endpoint
+func testVersionEndpoint(endpoint string) ConnectionTestResult {
+	start := time.Now()
+	result := ConnectionTestResult{
+		TestName: "Version Endpoint",
+	}
+
+	client, err := createHTTPClient(endpoint)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create HTTP client: %v", err)
+		return result
+	}
+
+	versionURL := normalizeURL(endpoint) + "/version"
+	req, err := http.NewRequest("GET", versionURL, nil)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create request: %v", err)
+		return result
+	}
+
+	resp, err := client.Do(req)
+	result.ResponseTime = time.Since(start)
+
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Request failed: %v", err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := strings.TrimSpace(string(body))
+	result.StatusCode = resp.StatusCode
+	result.Status = resp.Status
+	result.ResponseBody = bodyStr
+
+	if resp.StatusCode == http.StatusOK {
+		result.Success = true
+		result.Status = fmt.Sprintf("API Version: %s", bodyStr)
+	} else {
+		result.ErrorMessage = fmt.Sprintf("Version endpoint failed: status %d, body: %s", resp.StatusCode, bodyStr)
+	}
+
+	return result
+}
+
+// testAuthentication tests authentication with the provided token
+func testAuthentication(endpoint, token string) ConnectionTestResult {
+	start := time.Now()
+	result := ConnectionTestResult{
+		TestName: "Authentication",
+	}
+
+	client, err := createHTTPClient(endpoint)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create HTTP client: %v", err)
+		return result
+	}
+
+	// Use POST /analysis with valid JSON but an invalid repository URL
+	// The endpoint checks authentication AFTER JSON validation but BEFORE URL validation
+	// This allows us to test auth without triggering an actual analysis
+	// Flow: JSON validation -> Auth check -> URL validation
+	// - If auth fails: 401 Unauthorized
+	// - If auth passes but URL invalid: 400 Bad Request (auth test passed!)
+	testURL := normalizeURL(endpoint) + "/analysis"
+	
+	// Create a minimal valid JSON payload with an invalid repository URL
+	// This will pass JSON validation but fail URL validation after auth check
+	payload := map[string]string{
+		"repositoryURL":      "https://test-auth-validation.invalid/repo.git",
+		"repositoryBranch":   "main",
+	}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create request payload: %v", err)
+		return result
+	}
+
+	req, err := http.NewRequest("POST", testURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Failed to create request: %v", err)
+		return result
+	}
+
+	req.Header.Set("Husky-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "huskyci-cli")
+
+	resp, err := client.Do(req)
+	result.ResponseTime = time.Since(start)
+
+	if err != nil {
+		result.ErrorMessage = fmt.Sprintf("Request failed: %v", err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := strings.TrimSpace(string(body))
+	result.StatusCode = resp.StatusCode
+	result.Status = resp.Status
+	result.ResponseBody = bodyStr
+
+	// Parse response to determine authentication status
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// Token is invalid or doesn't have permission
+		// The server checked auth and rejected it
+		result.ErrorMessage = fmt.Sprintf("Authentication failed: token is invalid or expired (status %d)", resp.StatusCode)
+		if bodyStr != "" {
+			// Try to extract error message from JSON response
+			var errorResp map[string]interface{}
+			if err := json.Unmarshal(body, &errorResp); err == nil {
+				if msg, ok := errorResp["message"].(string); ok {
+					result.ErrorMessage = fmt.Sprintf("Authentication failed: %s", msg)
+				} else if errMsg, ok := errorResp["error"].(string); ok {
+					result.ErrorMessage = fmt.Sprintf("Authentication failed: %s", errMsg)
+				}
+			}
+		}
+	case http.StatusBadRequest:
+		// Bad request could mean:
+		// 1. JSON validation failed (unlikely with our valid JSON)
+		// 2. URL validation failed (happens AFTER auth check passes)
+		// Since we're sending valid JSON, a 400 typically means auth passed but URL is invalid
+		// Check the error message to be more precise
+		var errorResp map[string]interface{}
+		if bodyStr != "" {
+			if err := json.Unmarshal(body, &errorResp); err == nil {
+				if msg, ok := errorResp["message"].(string); ok {
+					// If error mentions JSON format, it's a JSON validation error (unlikely)
+					// Otherwise, it's likely URL validation (which happens after auth)
+					if strings.Contains(strings.ToLower(msg), "json") || strings.Contains(strings.ToLower(msg), "format") {
+						result.ErrorMessage = fmt.Sprintf("Unexpected JSON validation error: %s", msg)
+					} else {
+						// URL validation error means auth passed!
+						result.Success = true
+						result.Status = "Authentication successful (token is valid)"
+						if IsVerbose() {
+							result.Status += fmt.Sprintf(" - URL validation failed as expected: %s", msg)
+						}
+					}
+				} else {
+					// No message field, assume auth passed (URL validation failed)
+					result.Success = true
+					result.Status = "Authentication successful (token is valid)"
+				}
+			} else {
+				// Couldn't parse JSON, but 400 with our valid JSON likely means auth passed
+				result.Success = true
+				result.Status = "Authentication successful (token is valid)"
+			}
+		} else {
+			// Empty body with 400, assume auth passed
+			result.Success = true
+			result.Status = "Authentication successful (token is valid)"
+		}
+	case http.StatusOK:
+		// Request succeeded completely - authentication successful
+		result.Success = true
+		result.Status = "Authentication successful (token is valid)"
+	default:
+		// Other status codes
+		if resp.StatusCode < 400 {
+			result.Success = true
+			result.Status = fmt.Sprintf("Authentication successful (status %d)", resp.StatusCode)
+		} else if resp.StatusCode >= 500 {
+			result.ErrorMessage = fmt.Sprintf("Server error during authentication test (status %d)", resp.StatusCode)
+			if bodyStr != "" {
+				result.ErrorMessage += fmt.Sprintf(" - %s", bodyStr)
+			}
+		} else {
+			// Other 4xx errors
+			result.ErrorMessage = fmt.Sprintf("Unexpected response: status %d", resp.StatusCode)
+			if bodyStr != "" {
+				result.ErrorMessage += fmt.Sprintf(" - %s", bodyStr)
+			}
+		}
+	}
+
+	return result
+}
+
+// printTestResult prints the result of a single test
+func printTestResult(result ConnectionTestResult) {
+	if result.Success {
+		fmt.Printf("✓ %s\n", result.Status)
+	} else {
+		fmt.Printf("✗ %s\n", result.Status)
+		if result.ErrorMessage != "" {
+			fmt.Printf("  Error: %s\n", result.ErrorMessage)
+		}
+	}
+
+	if IsVerbose() {
+		fmt.Printf("  Status Code: %d\n", result.StatusCode)
+		fmt.Printf("  Response Time: %v\n", result.ResponseTime)
+		if result.ResponseBody != "" {
+			fmt.Printf("  Response Body: %s\n", result.ResponseBody)
+		}
+	} else {
+		fmt.Printf("  Response Time: %v\n", result.ResponseTime)
+	}
+}
+
+// printTestSummary prints a summary of all test results
+func printTestSummary(results []ConnectionTestResult) {
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("  📊 Test Summary")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println()
+
+	passed := 0
+	failed := 0
+	skipped := 0
+
+	for _, result := range results {
+		if result.Success {
+			passed++
+			fmt.Printf("✓ %s\n", result.TestName)
+		} else if result.ErrorMessage != "" {
+			failed++
+			fmt.Printf("✗ %s: %s\n", result.TestName, result.ErrorMessage)
+		} else {
+			skipped++
+			fmt.Printf("⊘ %s (skipped)\n", result.TestName)
+		}
+	}
+
+	fmt.Println()
+	fmt.Printf("Total: %d passed, %d failed", passed, failed)
+	if skipped > 0 {
+		fmt.Printf(", %d skipped", skipped)
+	}
+	fmt.Println()
+
+	if failed == 0 {
+		fmt.Println()
+		fmt.Println("✅ All connection tests passed!")
+		fmt.Println("   Your huskyCI CLI is properly configured and ready to use.")
+	} else {
+		fmt.Println()
+		fmt.Println("⚠️  Some tests failed. Please check:")
+		fmt.Println("   • Network connectivity")
+		fmt.Println("   • API endpoint URL is correct")
+		fmt.Println("   • API server is running")
+		fmt.Println("   • Authentication token is valid (if required)")
+		fmt.Println()
+		fmt.Println("   Use 'huskyci setup' to reconfigure or 'huskyci target-list' to check targets.")
+	}
+	fmt.Println()
+}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -12,6 +12,13 @@ import (
 	"github.com/spf13/viper"
 )
 
+// GetTokenFromEnv returns the authentication token from environment variables.
+// It checks HUSKYCI_CLI_TOKEN environment variable.
+// Returns empty string if not set.
+func GetTokenFromEnv() string {
+	return os.Getenv("HUSKYCI_CLI_TOKEN")
+}
+
 // GetCurrentTarget return a types.Target with current target
 func GetCurrentTarget() (*types.Target, error) {
 	// Get current targets
@@ -21,7 +28,7 @@ func GetCurrentTarget() (*types.Target, error) {
 		currentTarget.Endpoint = os.Getenv("HUSKYCI_CLIENT_API_ADDR")
 		currentTarget.Label = "env-var"
 		currentTarget.TokenStorage = "env-var"
-		currentTarget.Token = os.Getenv("HUSKYCI_CLIENT_TOKEN")
+		currentTarget.Token = GetTokenFromEnv()
 	} else {
 		targets := viper.GetStringMap("targets")
 		for k, v := range targets {
@@ -44,6 +51,9 @@ func GetCurrentTarget() (*types.Target, error) {
 				} else {
 					currentTarget.TokenStorage = target["token-storage"].(string)
 				}
+
+				// Always check for token from environment variable
+				currentTarget.Token = GetTokenFromEnv()
 
 			}
 		}

--- a/cli/types/types.go
+++ b/cli/types/types.go
@@ -20,6 +20,7 @@ type JSONPayload struct {
 	RepositoryURL      string          `json:"repositoryURL"`
 	RepositoryBranch   string          `json:"repositoryBranch"`
 	LanguageExclusions map[string]bool `json:"languageExclusions"`
+	EnryOutput         string          `json:"enryOutput,omitempty"` // Optional: Enry JSON output from CLI for file:// URLs
 }
 
 // Target is the struct that represents HuskyCI API target

--- a/cli/util/docker.go
+++ b/cli/util/docker.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// ErrConnectionRefused is returned when the connection error looks like "connection refused".
+var ErrConnectionRefused = errors.New("connection refused")
+
+// IsConnectionRefused reports whether err indicates a connection refused (e.g. nothing listening on the address).
+func IsConnectionRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "connect: connection refused") ||
+		strings.Contains(s, "dial tcp") && strings.Contains(s, "refused")
+}
+
+// IsLocalEndpoint reports whether the given endpoint URL is a local address
+// (localhost or 127.0.0.1), where "start Docker" is a reasonable suggestion.
+func IsLocalEndpoint(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+// PromptAndStartDocker asks the user if they want to start Docker and, if yes,
+// starts Docker (e.g. Docker Desktop). It reads a line from r (e.g. os.Stdin).
+// Returns true if the user approved and StartDocker was run (caller may retry);
+// false otherwise.
+func PromptAndStartDocker(r io.Reader) bool {
+	fmt.Println()
+	fmt.Println("  Docker may not be running. The huskyCI API often runs in Docker.")
+	fmt.Print("  Start Docker now? [y/N]: ")
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		return false
+	}
+	line := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	if line != "y" && line != "yes" {
+		return false
+	}
+	if err := StartDocker(); err != nil {
+		fmt.Fprintf(os.Stderr, "  Failed to start Docker: %v\n", err)
+		fmt.Fprintln(os.Stderr, "  Please start Docker manually and try again.")
+		return false
+	}
+	fmt.Println("  Docker is starting. Wait a moment, then the CLI will retry.")
+	return true
+}
+
+// StartDocker starts the Docker daemon / Docker Desktop for the current OS.
+// On macOS it runs "open -a Docker". On Linux/Windows it returns a hint error
+// so the user can start Docker manually.
+func StartDocker() error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", "-a", "Docker").Run()
+	case "linux":
+		// systemctl start docker often requires root; suggest manual start
+		cmd := exec.Command("systemctl", "--user", "start", "docker")
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("could not start Docker: %w (try: systemctl start docker, or start Docker Desktop)", err)
+		}
+		return nil
+	case "windows":
+		// Docker Desktop on Windows can be started via COM or by running the executable
+		return fmt.Errorf("please start Docker Desktop manually from the Start menu")
+	default:
+		return fmt.Errorf("please start Docker manually for %s", runtime.GOOS)
+	}
+}

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -189,3 +189,11 @@ func AppendIfMissing(slice []string, s string) []string {
 	}
 	return append(slice, s)
 }
+
+// NormalizeURL removes trailing slashes from a URL
+func NormalizeURL(url string) string {
+	if strings.HasSuffix(url, "/") {
+		return url[:len(url)-1]
+	}
+	return url
+}

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -47,6 +47,7 @@ func StartAnalysis() (string, error) {
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Husky-Token", config.HuskyToken)
+	req.Header.Add("User-Agent", "huskyci-client")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -108,6 +109,7 @@ func GetAnalysis(RID string) (types.Analysis, error) {
 	}
 
 	req.Header.Add("Husky-Token", config.HuskyToken)
+	req.Header.Add("User-Agent", "huskyci-client")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -7,11 +7,12 @@ services:
         container_name: huskyCI_Docker_API
         command: "dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376"
         ports:
-          - "2376:2376"
+            - "2376:2376"
         volumes:
             - docker_vol:/var/lib/docker
             - ../deployments/daemon.json:/etc/docker/daemon.json:ro
             - ../deployments/certs:/data/certs
+            - /tmp/huskyci-zips-host:/tmp/huskyci-zips
         networks:
             - huskyCI_net
 
@@ -40,6 +41,7 @@ services:
             - ../deployments/certs/server-dockerapi-key.pem:/go/src/github.com/huskyci-org/huskyCI/key.pem:ro
             - ../deployments/certs/ca.pem:/go/src/github.com/huskyci-org/huskyCI/ca.pem:ro
             - ../deployments/kubeconfig:/go/src/github.com/huskyci-org/huskyCI/kubeconfig
+            - /tmp/huskyci-zips-host:/tmp/huskyci-zips
         ports:
           - "8888:8888"
         networks:

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
 
     dockerapi:
@@ -15,6 +14,12 @@ services:
             - /tmp/huskyci-zips-host:/tmp/huskyci-zips
         networks:
             - huskyCI_net
+        healthcheck:
+            test: ["CMD", "docker", "info"]
+            interval: 5s
+            timeout: 5s
+            retries: 10
+            start_period: 15s
 
     api:
         container_name: huskyCI_API
@@ -50,7 +55,7 @@ services:
             mongodb:
                 condition: service_healthy
             dockerapi:
-                condition: service_started
+                condition: service_healthy
         external_links:
             - dockerapi:dockerapi
 

--- a/deployments/dockerfiles/api.Dockerfile
+++ b/deployments/dockerfiles/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine as builder
+FROM golang:1.24-alpine AS builder
 
 ADD api/ /go/src/github.com/huskyci-org/huskyCI/api/
 WORKDIR /go/src/github.com/huskyci-org/huskyCI/api/

--- a/docs/WORKTREE_SPLIT_AND_NAVIGATION.md
+++ b/docs/WORKTREE_SPLIT_AND_NAVIGATION.md
@@ -1,0 +1,276 @@
+# Git worktrees: feature split and navigation
+
+This document explains how to split the current `feat/setup-wizard-command` changes into **separate git worktrees** (one per feature) and how to work with multiple worktrees in this repo.
+
+---
+
+## 1. Proposed feature split (worktrees)
+
+Current modifications are grouped into **three features**. Each gets its own branch and worktree.
+
+| Feature | Branch name | Purpose |
+|--------|-------------|--------|
+| **Setup wizard & test-connection** | `feat/setup-wizard-command` | CLI setup wizard, `test-connection` command, local deployment docs |
+| **Zip upload for analysis** | `feat/zip-upload-analysis` | API: upload zip, store, extract for local/repo analysis |
+| **Multi-platform Docker builds** | `feat/multi-platform-docker-builds` | Scripts and Dockerfiles for building/pushing amd64+arm64 images |
+
+### 1.1 Files per worktree
+
+**Worktree 1 – Setup wizard & test-connection** (`feat/setup-wizard-command`)
+
+- **CLI:** `cli/cmd/setup.go`, `cli/cmd/testConnection.go`, `cli/analysis/analysis.go`, `cli/config/config.go`, `cli/types/types.go`, `cli/util/util.go`
+- **Client:** `client/analysis/analysis.go`
+- **API (for local dev / healthcheck / version / token):** `api/server.go`, `api/routes/token.go`, `api/routes/analysis.go` (only changes for healthcheck/version if split; otherwise keep analysis.go in zip worktree and accept overlap), `api/token/generator.go`, `api/token/token.go`, `api/token/token_test.go`, `api/config.yaml`, `api/dockers/api.go`, `api/dockers/huskydocker.go`, `api/kubernetes/api.go`, `api/kubernetes/huskykube.go`, `api/types/types.go`, `api/util/api/api.go`, `api/util/util.go`, `api/log/messagecodes.go`
+- **Deploy / docs:** `deployments/docker-compose.yml`, `LOCAL_DEPLOYMENT.md`, `README.md`, `tests/e2e/README.md`
+
+**Worktree 2 – Zip upload for analysis** (`feat/zip-upload-analysis`)
+
+- **New:** `api/util/zip.go`
+- **Modified:** `api/routes/analysis.go` (UploadZip + zip flow in StartAnalysis), `api/analysis/analysis.go`, `api/dockers/api.go`, `api/dockers/huskydocker.go`, `api/server.go` (POST `/analysis/upload`), `api/log/messagecodes.go` (zip-related codes)
+
+**Worktree 3 – Multi-platform Docker builds** (`feat/multi-platform-docker-builds`)
+
+- **New:** `deployments/scripts/README-multi-platform-build.md`, `deployments/scripts/build-and-push-enry.sh`, `deployments/scripts/build-and-push-multi-platform.sh`
+- **Modified:** `deployments/dockerfiles/enry/Dockerfile`, `deployments/dockerfiles/spotbugs/Dockerfile`
+
+**Overlap note:** `api/server.go`, `api/routes/analysis.go`, `api/dockers/*`, `api/log/messagecodes.go` are used by both setup-wizard (local API) and zip-upload. Options: (a) keep these only in **setup-wizard** worktree and add zip changes there so zip is implemented on top of setup-wizard, or (b) keep zip worktree based on `main` and add only zip-specific changes there, then merge zip into setup-wizard later. The commands below use (a): **setup-wizard** worktree keeps the full current API (including zip); **zip-upload** worktree is optional for a “zip-only” branch from `main` if you want to merge that separately.
+
+---
+
+## 2. Creating the worktrees (step-by-step)
+
+Assume repo root: `/Users/guilherme.ferreira/Gits/huskyCI` and default branch `main`. Adjust paths if your clone lives elsewhere.
+
+### 2.1 Save current state
+
+```bash
+cd /Users/guilherme.ferreira/Gits/huskyCI
+
+# Option A: commit everything on current branch (simplest for later reference)
+git add -A
+git status   # review
+git commit -m "WIP: setup wizard, zip upload, multi-platform scripts (to be split)"
+
+# Option B: or create a patch of all changes and stash
+# git add -A && git diff --cached > /tmp/huskyci-all-changes.patch && git reset HEAD
+```
+
+### 2.2 Create worktree for setup wizard (keep as main feature tree)
+
+This worktree keeps the **full** current feature set (setup wizard + zip + docker-compose, etc.). You can later strip zip or multi-platform from this branch if you want a “setup only” branch.
+
+```bash
+cd /Users/guilherme.ferreira/Gits/huskyCI
+
+# Already on feat/setup-wizard-command; if you committed in 2.1, this worktree is “current”
+# To create a dedicated worktree for this branch elsewhere (e.g. ../huskyCI-setup-wizard):
+git worktree add ../huskyCI-setup-wizard feat/setup-wizard-command
+```
+
+So:
+
+- **Main repo** `huskyCI` can stay on `feat/setup-wizard-command` (or `main`).
+- **../huskyCI-setup-wizard** = worktree for `feat/setup-wizard-command` with all current changes.
+
+### 2.3 Create worktree for zip-upload (zip-only branch from main)
+
+Use a new branch from `main` and bring only zip-related changes into this worktree.
+
+```bash
+cd /Users/guilherme.ferreira/Gits/huskyCI
+
+git worktree add -b feat/zip-upload-analysis ../huskyCI-zip-upload main
+cd ../huskyCI-zip-upload
+
+# Copy zip-related files from the commit you created in 2.1
+COMMIT=$(git -C /Users/guilherme.ferreira/Gits/huskyCI rev-parse feat/setup-wizard-command)
+git checkout "$COMMIT" -- api/util/zip.go api/routes/analysis.go api/analysis/analysis.go api/dockers/api.go api/dockers/huskydocker.go api/server.go api/log/messagecodes.go
+git add -A && git commit -m "feat(api): zip upload for analysis"
+```
+
+So:
+
+- **../huskyCI-zip-upload** = worktree for `feat/zip-upload-analysis` (zip-only API changes).
+
+### 2.4 Create worktree for multi-platform Docker builds
+
+```bash
+cd /Users/guilherme.ferreira/Gits/huskyCI
+
+git worktree add -b feat/multi-platform-docker-builds ../huskyCI-multi-platform main
+cd ../huskyCI-multi-platform
+
+# Copy script and Dockerfile changes from your WIP commit
+COMMIT=$(git -C /Users/guilherme.ferreira/Gits/huskyCI rev-parse feat/setup-wizard-command)
+git checkout "$COMMIT" -- deployments/scripts/ deployments/dockerfiles/enry/Dockerfile deployments/dockerfiles/spotbugs/Dockerfile
+git add -A && git commit -m "feat(deploy): multi-platform Docker build scripts"
+```
+
+So:
+
+- **../huskyCI-multi-platform** = worktree for `feat/multi-platform-docker-builds`.
+
+### 2.5 Summary of worktree layout
+
+| Worktree path | Branch | Purpose |
+|---------------|--------|--------|
+| `.../huskyCI` | `feat/setup-wizard-command` or `main` | Main repo (or “setup” branch) |
+| `.../huskyCI-setup-wizard` | `feat/setup-wizard-command` | Setup wizard + test-connection + local deploy |
+| `.../huskyCI-zip-upload` | `feat/zip-upload-analysis` | Zip upload for analysis |
+| `.../huskyCI-multi-platform` | `feat/multi-platform-docker-builds` | Multi-platform build scripts |
+
+---
+
+## 3. Navigating and managing worktrees
+
+### 3.1 List worktrees
+
+```bash
+# From anywhere (repo or worktree)
+git worktree list
+```
+
+Example output:
+
+```
+/Users/guilherme.ferreira/Gits/huskyCI              abc1234 [feat/setup-wizard-command]
+/Users/guilherme.ferreira/Gits/huskyCI-setup-wizard def5678 [feat/setup-wizard-command]
+/Users/guilherme.ferreira/Gits/huskyCI-zip-upload   a1b2c3d [feat/zip-upload-analysis]
+/Users/guilherme.ferreira/Gits/huskyCI-multi-platform 9e8d7c6 [feat/multi-platform-docker-builds]
+```
+
+### 3.2 Switch “where you work” (change directory)
+
+Each worktree is a separate directory; you “switch” by changing directory and using that tree’s branch.
+
+```bash
+# Work on setup wizard
+cd /Users/guilherme.ferreira/Gits/huskyCI-setup-wizard
+git status   # branch: feat/setup-wizard-command
+
+# Work on zip upload
+cd /Users/guilherme.ferreira/Gits/huskyCI-zip-upload
+git status   # branch: feat/zip-upload-analysis
+
+# Work on multi-platform builds
+cd /Users/guilherme.ferreira/Gits/huskyCI-multi-platform
+git status   # branch: feat/multi-platform-docker-builds
+```
+
+No “checkout” of branch is needed when moving between worktrees: the directory is already bound to its branch.
+
+### 3.3 Create a new worktree (generic)
+
+```bash
+# New worktree for an existing branch
+git worktree add <path> <branch>
+
+# Example: work on main in a separate folder
+git worktree add ../huskyCI-main main
+
+# New worktree with a new branch (branch is created from current HEAD of <start-branch>)
+git worktree add -b <new-branch> <path> <start-branch>
+
+# Example: new feature branch from main
+git worktree add -b feat/my-feature ../huskyCI-my-feature main
+```
+
+### 3.4 Remove a worktree
+
+```bash
+# From main repo (or any worktree)
+cd /Users/guilherme.ferreira/Gits/huskyCI
+git worktree remove ../huskyCI-zip-upload
+
+# If the worktree has uncommitted changes or is “dirty”, force remove:
+git worktree remove --force ../huskyCI-zip-upload
+```
+
+You can also delete the directory yourself and then run `git worktree prune` in the main repo to clean the worktree list.
+
+### 3.5 Prune stale worktree references
+
+After deleting a worktree directory manually:
+
+```bash
+cd /Users/guilherme.ferreira/Gits/huskyCI
+git worktree prune
+```
+
+### 3.6 See which branch is checked out in each worktree
+
+```bash
+git worktree list
+# or
+git branch -a
+# and compare with:
+for wt in $(git worktree list --porcelain | awk '/^worktree/ {print $2}'); do
+  echo "=== $wt ===" && (cd "$wt" && git branch --show-current && git status -sb)
+done
+```
+
+### 3.7 Build or run in a specific worktree
+
+```bash
+# Build CLI in setup-wizard worktree
+cd /Users/guilherme.ferreira/Gits/huskyCI-setup-wizard
+make build   # or go build ./cli/...
+
+# Run API in zip-upload worktree
+cd /Users/guilherme.ferreira/Gits/huskyCI-zip-upload
+make run-api # or whatever your Makefile uses
+```
+
+### 3.8 Merge order (when features are ready)
+
+1. Merge **feat/zip-upload-analysis** into **feat/setup-wizard-command** (if you kept zip in setup-wizard, you may already have it).
+2. Merge **feat/multi-platform-docker-builds** into **feat/setup-wizard-command** (or into **main**).
+3. Merge **feat/setup-wizard-command** into **main**.
+
+Example:
+
+```bash
+cd /Users/guilherme.ferreira/Gits/huskyCI-setup-wizard
+git fetch origin
+git merge feat/zip-upload-analysis
+git merge feat/multi-platform-docker-builds
+# resolve conflicts if any, then push
+```
+
+---
+
+## 4. Quick reference: create worktrees (copy-paste)
+
+```bash
+# 1) From huskyCI repo root
+cd /Users/guilherme.ferreira/Gits/huskyCI
+
+# 2) Ensure you have a commit with your current work (optional but recommended)
+git add -A && git status
+git commit -m "WIP: all changes (to split into worktrees)" || true
+
+# 3) Setup wizard worktree (current branch)
+git worktree add ../huskyCI-setup-wizard feat/setup-wizard-command
+
+# 4) Zip-upload worktree (new branch from main)
+git worktree add -b feat/zip-upload-analysis ../huskyCI-zip-upload main
+
+# 5) Multi-platform worktree (new branch from main)
+git worktree add -b feat/multi-platform-docker-builds ../huskyCI-multi-platform main
+
+# 6) List
+git worktree list
+```
+
+After that, copy only the files that belong to each feature into **huskyCI-zip-upload** and **huskyCI-multi-platform** from your WIP commit (e.g. `git checkout <commit> -- <files>`), then commit in each worktree. The **huskyCI-setup-wizard** worktree already has the full state if you committed in step 2.
+
+---
+
+## 5. Summary
+
+- **Split:** One worktree per feature (setup wizard, zip upload, multi-platform builds); each has its own branch and directory.
+- **Navigate:** `cd` to the worktree directory; that directory is tied to one branch.
+- **Create:** `git worktree add <path> <branch>` or `git worktree add -b <new-branch> <path> <start-branch>`.
+- **List/remove:** `git worktree list`, `git worktree remove <path>`, `git worktree prune`.
+
+This keeps features isolated while sharing the same repo history and makes it easier to open different worktrees in different editor windows or to run different branches side by side.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -35,8 +35,9 @@ The E2E tests verify:
 
 3. **Wait for services to be ready** (usually takes 1-2 minutes):
    ```bash
-   # Check MongoDB
-   docker exec huskyCI_MongoDB mongosh --eval "db.adminCommand('ping')"
+   # Check MongoDB (MongoDB 4.4 uses 'mongo' command, not 'mongosh')
+   # Simple check - just verify the container is responding
+   docker exec huskyCI_MongoDB mongo --eval "db.adminCommand('ping')" --quiet
    
    # Check API
    curl http://localhost:8888/healthcheck
@@ -79,7 +80,7 @@ You can customize the test behavior by modifying these variables in `run-e2e-tes
 
 - Ensure Docker Compose services are running: `docker-compose -f deployments/docker-compose.yml ps`
 - Check if the API is accessible: `curl http://localhost:8888/healthcheck`
-- Verify MongoDB is healthy: `docker exec huskyCI_MongoDB mongosh --eval "db.adminCommand('ping')"`
+- Verify MongoDB is healthy: `docker exec huskyCI_MongoDB mongo --eval "db.adminCommand('ping')" --quiet`
 
 ### Tests timeout waiting for analysis
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -53,6 +53,21 @@ The E2E tests verify:
    make compose-down
    ```
 
+## Running E2E Tests on Feature Branches (before merge to main)
+
+To run E2E on each feature branch before merging to `main`:
+
+1. **Start Docker** (required for compose and E2E).
+2. From the repo root:
+   ```bash
+   ./tests/e2e/run-e2e-per-branch.sh
+   ```
+   By default this runs E2E on `feat/multi-platform-docker-builds` and `feat/setup-wizard-command` (branches that build the full API). If the API does not build on a branch (e.g. `feat/zip-upload-analysis`, which is API-only and depends on `main`), that branch is skipped; validate it by merging into `feat/setup-wizard-command` (or `main`) and running E2E there.
+3. To run E2E on specific branches:
+   ```bash
+   ./tests/e2e/run-e2e-per-branch.sh feat/setup-wizard-command
+   ```
+
 ## Running E2E Tests in CI/CD
 
 The E2E tests are automatically run in GitHub Actions on:

--- a/tests/e2e/run-e2e-per-branch.sh
+++ b/tests/e2e/run-e2e-per-branch.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Runs E2E tests on each feature branch and reports results.
+# Requires: Docker daemon running, make, curl.
+#
+# Note: feat/zip-upload-analysis does not build standalone (depends on types/securitytest
+# from main). It is validated when merged into feat/setup-wizard-command or main.
+# Default branches: feat/multi-platform-docker-builds feat/setup-wizard-command
+#
+# Usage: ./tests/e2e/run-e2e-per-branch.sh [branch1 branch2 ...]
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+BRANCHES=("${@:-feat/multi-platform-docker-builds feat/setup-wizard-command}")
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+run_e2e_for_branch() {
+    local branch="$1"
+    echo -e "\n${YELLOW}========== E2E tests for branch: $branch ==========${NC}"
+    git checkout "$branch" || { echo -e "${RED}Failed to checkout $branch${NC}"; return 1; }
+
+    echo "Checking API build..."
+    if ! make build-api >/dev/null 2>&1; then
+        echo -e "${YELLOW}Branch $branch does not build API (e.g. zip-only branch). Skipping E2E.${NC}"
+        echo "Validate this feature by merging into feat/setup-wizard-command and running E2E there."
+        return 0
+    fi
+
+    echo "Creating certificates (if needed)..."
+    make create-certs || true
+
+    echo "Starting compose (API + MongoDB + Docker API)..."
+    make compose
+
+    echo "Waiting for API to be ready (up to 120s)..."
+    local i=0
+    while [ $i -lt 24 ]; do
+        if curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/healthcheck 2>/dev/null | grep -q 200; then
+            echo "API is ready."
+            break
+        fi
+        sleep 5
+        i=$((i + 1))
+    done
+    if [ $i -eq 24 ]; then
+        echo -e "${RED}API did not become ready in time.${NC}"
+        make compose-down 2>/dev/null || true
+        return 1
+    fi
+
+    echo "Running E2E tests..."
+    if make test-e2e; then
+        echo -e "${GREEN}✓ E2E passed for $branch${NC}"
+        make compose-down 2>/dev/null || true
+        return 0
+    else
+        echo -e "${RED}✗ E2E failed for $branch${NC}"
+        make compose-down 2>/dev/null || true
+        return 1
+    fi
+}
+
+echo "E2E tests per branch. Repo root: $REPO_ROOT"
+echo "Branches: ${BRANCHES[*]}"
+
+if ! docker info >/dev/null 2>&1; then
+    echo -e "${RED}Docker daemon is not running. Start Docker and re-run this script.${NC}"
+    exit 1
+fi
+
+FAILED=()
+for b in "${BRANCHES[@]}"; do
+    if run_e2e_for_branch "$b"; then
+        :
+    else
+        FAILED+=("$b")
+    fi
+done
+
+echo -e "\n${YELLOW}========== Summary ==========${NC}"
+if [ ${#FAILED[@]} -eq 0 ]; then
+    echo -e "${GREEN}All branches passed E2E. Safe to merge to main.${NC}"
+    exit 0
+else
+    echo -e "${RED}Failed branches: ${FAILED[*]}${NC}"
+    exit 1
+fi


### PR DESCRIPTION
# Replace glbgelf with log/slog

## Summary

- Replaces the github.com/globocom/glbgelf dependency with the standard library log/slog (Go 1.21+). All logging still goes through the existing api/log API (log.Info, log.Warning, log.Error, log.InitLog); only the implementation and output format change.

## Motivation

- Remove external logging dependency and rely on the standard library.
- Improve log readability: one-line text in development, structured JSON in production.
- No compatibility with the old interface: tests use slog (e.g. buffer + handler) instead of a SendLog stub.

## Changes

- api/log/log.go: Removed the logger interface and glbgelf. Uses a package-level *slog.Logger; InitLog chooses slog.TextHandler (dev) or slog.JSONHandler (prod) and sets app/tags. Info/Warning/Error build a single msg from MsgCode[msgCode] plus variadic args and log with attributes action, info, msg_code. Added SetLogger and DefaultLogger for tests.
- api/log/log_test.go: Dropped stubLogger/SendLog. Tests set a logger that writes to a buffer and assert on slog output (level, msg, attributes).
- api/util/api/api_test.go and api_suite_test.go: Use log.InitLog instead of glbgelf.InitLogger; assertion updated to log.DefaultLogger() != nil.
- api/go.mod / api/go.sum: Removed the glbgelf dependency and ran go mod tidy.

## Log format

- Development (default or HUSKYCI_LOGGING_GRAYLOG_DEV not set to false): One-line text, e.g.
time=... level=INFO msg="Starting HuskyCI." app=huskyCI tags=huskyCI action=main info=SERVER msg_code=11
- Production (HUSKYCI_LOGGING_GRAYLOG_DEV=false): One JSON object per line with time, level, msg, app, tags, action, info, msg_code.

## Testing

- go test ./api/log/... passes.
- Dev and prod log formats checked by starting the API with and without HUSKYCI_LOGGING_GRAYLOG_DEV=false.
- No remaining references to glbgelf or SendLog in api/.

## Checklist
- [x] Call sites unchanged (log.Info/Warning/Error/InitLog).
- [x] glbgelf removed from api/go.mod.
- [x] Log package tests updated and passing.
- [x] Dev/prod formats verified manually.